### PR TITLE
fix: Fix diabetes related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,22 +47,25 @@ Since this package is using Swift you might also need to add a bridging header i
   console.log(unit) // %
 
   /* Listen to data */
-  await HealthKit.requestAuthorization([HKQuantityTypeIdentifier.heartRate]); // request read permission for bodyFatPercentage
+  await HealthKit.requestAuthorization([HKQuantityTypeIdentifier.heartRate]); // request read permission for heart rate
 
   const unsubscribe = HealthKit.subscribeToChanges(HKQuantityTypeIdentifier.heartRate, () => {
     // refetch whichever queries you need
   });
 
   /* write data */
-  await HealthKit.requestAuthorization([], [HKQuantityTypeIdentifier.bloodGlucose]); // request write permission for bodyFatPercentage
+  await HealthKit.requestAuthorization([], [HKQuantityTypeIdentifier.insulinDelivery]); // request write permission for insulin delivery
 
   ReactNativeHealthkit.saveQuantitySample(
-      HKQuantityTypeIdentifier.bloodGlucose,
-      HKUnit.GlucoseMmolPerL,
+      HKQuantityTypeIdentifier.insulinDelivery,
+      HKUnit.InternationalUnit,
       5.5,
       {
         metadata: {
-          HKMetadataKeyInsulinDeliveryReason: HKInsulinDeliveryReason.basal,
+          // Metadata keys could be arbirtary string to store app-specific data.
+          // To use built-in types from https://developer.apple.com/documentation/healthkit/samples/metadata_keys
+          // you need to specify string values instead of variable names (by dropping MetadataKey from the name).
+          HKInsulinDeliveryReason: HKInsulinDeliveryReason.basal,
         },
       }
     );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -18,6 +18,7 @@ import Healthkit, {
   HKUnit,
   HKWeatherCondition,
   HKWorkoutActivityType,
+  HKInsulinDeliveryReason,
 } from '../../src/index';
 
 const DisplayWorkout: React.FunctionComponent<{
@@ -158,16 +159,16 @@ function DataView() {
   ] = React.useState<QueryStatisticsResponse | null>(null);
 
   React.useEffect(() => {
-    /*Healthkit.saveQuantitySample(
-      HKQuantityTypeIdentifier.bloodGlucose,
-      HKUnit.GlucoseMmolPerL,
+    Healthkit.saveQuantitySample(
+      HKQuantityTypeIdentifier.insulinDelivery,
+      HKUnit.InternationalUnit,
       4.2,
       {
         metadata: {
-          HKMetadataKeyInsulinDeliveryReason: HKInsulinDeliveryReason.basal,
+          HKInsulinDeliveryReason: HKInsulinDeliveryReason.basal,
         },
       }
-    );*/
+    );
     Healthkit.saveCorrelationSample(HKCorrelationTypeIdentifier.food, [
       {
         quantityType: HKQuantityTypeIdentifier.dietaryCaffeine,
@@ -202,7 +203,7 @@ function DataView() {
       new Date(),
       {
         metadata: {
-          HKMetadataKeyWeatherCondition: HKWeatherCondition.hurricane,
+          HKWeatherCondition: HKWeatherCondition.hurricane,
         },
       }
     );

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -128,20 +128,21 @@ export enum HKWorkoutActivityType {
 }
 
 export type HKGenericMetadata = {
-  HKMetadataKeyExternalUUID?: string;
-  HKMetadataKeyTimeZone?: string;
-  HKMetadataKeyWasUserEntered?: boolean;
-  HKMetadataKeyDeviceSerialNumber?: string;
-  HKMetadataKeyUDIDeviceIdentifier?: string;
-  HKMetadataKeyUDIProductionIdentifier?: string;
-  HKMetadataKeyDigitalSignature?: string;
-  HKMetadataKeyDeviceName?: string;
-  HKMetadataKeyDeviceManufacturerName?: string;
-  HKMetadataKeySyncIdentifier?: string;
-  HKMetadataKeySyncVersion?: number;
-  HKMetadataKeyWasTakenInLab?: boolean;
-  HKMetadataKeyReferenceRangeLowerLimit?: number;
-  HKMetadataKeyReferenceRangeUpperLimit?: number;
+  [key: string]: string | number | boolean | HKQuantity | undefined;
+  HKExternalUUID?: string;
+  HKTimeZone?: string;
+  HKWasUserEntered?: boolean;
+  HKDeviceSerialNumber?: string;
+  HKUDIDeviceIdentifier?: string;
+  HKUDIProductionIdentifier?: string;
+  HKDigitalSignature?: string;
+  HKDeviceName?: string;
+  HKDeviceManufacturerName?: string;
+  HKSyncIdentifier?: string;
+  HKSyncVersion?: number;
+  HKWasTakenInLab?: boolean;
+  HKReferenceRangeLowerLimit?: number;
+  HKReferenceRangeUpperLimit?: number;
 };
 
 // documented at https://developer.apple.com/documentation/healthkit/hkweathercondition
@@ -178,9 +179,9 @@ export enum HKWeatherCondition {
 
 export interface HKWorkoutMetadata
   extends HKGenericMetadata /*<TTemperatureUnit extends HKUnit>*/ {
-  HKMetadataKeyWeatherCondition?: HKWeatherCondition;
-  HKMetadataKeyWeatherHumidity?: HKQuantity<HKUnit.Percent>;
-  // HKMetadataKeyWeatherTemperature: HKQuantity<TTemperatureUnit>
+  HKWeatherCondition?: HKWeatherCondition;
+  HKWeatherHumidity?: HKQuantity<HKUnit.Percent>;
+  // HKWeatherTemperature: HKQuantity<TTemperatureUnit>
 }
 
 // Straight mapping to https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier
@@ -415,14 +416,17 @@ export enum HKInsulinDeliveryReason {
 
 export type MetadataMapperForQuantityIdentifier<
   TQuantityTypeIdentifier = HKQuantityTypeIdentifier
-> = TQuantityTypeIdentifier extends HKQuantityTypeIdentifier.bloodGlucose
+> = TQuantityTypeIdentifier extends HKQuantityTypeIdentifier.insulinDelivery
   ? HKGenericMetadata & {
-      HKMetadataKeyBloodGlucoseMealTime?: number;
-      HKMetadataKeyInsulinDeliveryReason?: HKInsulinDeliveryReason;
+      HKInsulinDeliveryReason: HKInsulinDeliveryReason;
+    }
+  : TQuantityTypeIdentifier extends HKQuantityTypeIdentifier.bloodGlucose
+  ? HKGenericMetadata & {
+      HKBloodGlucoseMealTime?: number;
     }
   : TQuantityTypeIdentifier extends HKQuantityTypeIdentifier.heartRate
   ? HKGenericMetadata & {
-      HKMetadataKeyHeartRateMotionContext?: HKHeartRateMotionContext;
+      HKHeartRateMotionContext?: HKHeartRateMotionContext;
     }
   : HKGenericMetadata;
 
@@ -430,7 +434,7 @@ export type MetadataMapperForCorrelationIdentifier<
   TCorrelationTypeIdentifier = HKCorrelationTypeIdentifier
 > = TCorrelationTypeIdentifier extends HKCorrelationTypeIdentifier.food
   ? HKGenericMetadata & {
-      HKMetadataKeyFoodType?: string;
+      HKFoodType?: string;
     }
   : HKGenericMetadata;
 
@@ -460,11 +464,11 @@ export type MetadataMapperForCategoryIdentifier<
   T extends HKCategoryTypeIdentifier
 > = T extends HKCategoryTypeIdentifier.sexualActivity
   ? HKGenericMetadata & {
-      HKMetadataKeySexualActivityProtectionUsed: boolean;
+      HKSexualActivityProtectionUsed: boolean;
     }
   : T extends HKCategoryTypeIdentifier.menstrualFlow
   ? HKGenericMetadata & {
-      HKMetadataKeyMenstrualCycleStart: boolean;
+      HKMenstrualCycleStart: boolean;
     }
   : HKGenericMetadata;
 
@@ -544,6 +548,7 @@ export enum HKUnit {
   Yard = 'yd',
 
   GlucoseMmolPerL = 'mmol<180.15588000005408>/l',
+  GlucoseMgPerDl = 'mg/dL',
 }
 
 export type HKDevice = {


### PR DESCRIPTION
#### Add mg/dL as glucose unit
This unit is as common as mmol/l and specified in https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierbloodglucose

#### Fix sample metadata constraints for InsulinDeliveryReason
`HKMetadataKeyBloodGlucoseMealTime` is a key for `HKQuantityTypeIdentifier.bloodGlucose`, but `HKMetadataKeyInsulinDeliveryReason` is for `HKQuantityTypeIdentifier.insulinDelivery`.

I split the declaration and fixed examples in app and README.

#### Fix sample metadata keys
Metadata keys were not working and ignored, but attempts to use methods that had required metadata fields (such as `HKQuantityTypeIdentifier.insulinDelivery`) failed.

This is because on swift side `HKMetadataKeyInsulinDeliveryReason` is a variable rather than value. I chose to change all values on typescript side because it was too finicky to create a mapping on swift side.