### PR TITLE
Fix ascending

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,22 +1,22 @@
 import * as React from 'react';
-import { Text, ScrollView } from 'react-native';
+import { ScrollView, Text } from 'react-native';
 import { DataTable } from 'react-native-paper';
 import dayjs from 'dayjs';
 import Healthkit, {
+  HKCategorySample,
   HKCategoryTypeIdentifier,
   HKCharacteristicTypeIdentifier,
+  HKCorrelationTypeIdentifier,
+  HKInsulinDeliveryReason,
   HKQuantity,
   HKQuantitySample,
   HKQuantityTypeIdentifier,
   HKStatisticsOptions,
-  HKWorkout,
-  QueryStatisticsResponse,
-  HKCategorySample,
-  HKCorrelationTypeIdentifier,
   HKUnit,
   HKWeatherCondition,
+  HKWorkout,
   HKWorkoutActivityType,
-  HKInsulinDeliveryReason,
+  QueryStatisticsResponse,
 } from '../../src/index';
 
 const DisplayWorkout: React.FunctionComponent<{
@@ -25,7 +25,7 @@ const DisplayWorkout: React.FunctionComponent<{
   return (
     <DataTable.Row accessibilityStates={[]}>
       <DataTable.Cell accessibilityStates={[]}>
-        {workout.workoutActivityType}
+        {HKWorkoutActivityType[workout.workoutActivityType]}
       </DataTable.Cell>
       <DataTable.Cell
         style={{ paddingRight: 10 }}
@@ -124,6 +124,11 @@ const DisplayStat: React.FunctionComponent<{
 
 function DataView() {
   const [dateOfBirth, setDateOfBirth] = React.useState<Date | null>(null);
+
+  const [bloodGlucoseSamples, setBloodGlucoseSamples] = React.useState<Array<
+    HKQuantitySample
+  > | null>(null);
+
   const bodyFat = Healthkit.useMostRecentQuantitySample(
     HKQuantityTypeIdentifier.bodyFatPercentage
   );
@@ -209,7 +214,12 @@ function DataView() {
       ],
       dayjs().startOf('day').toDate()
     ).then(setQueryStatisticsResponse);
-    // });
+
+    Healthkit.queryQuantitySamples(HKQuantityTypeIdentifier.bloodGlucose, {
+      ascending: true,
+      from: dayjs().startOf('day').toDate(),
+      to: new Date(),
+    }).then(setBloodGlucoseSamples);
   }, []);
 
   return (
@@ -262,6 +272,26 @@ function DataView() {
           <DataTable.Title accessibilityStates={[]}>Energy</DataTable.Title>
         </DataTable.Header>
         {lastWorkout ? <DisplayWorkout workout={lastWorkout} /> : null}
+
+        <DataTable.Header accessibilityStates={[]}>
+          <DataTable.Title accessibilityStates={[]}>
+            Blood Glucose
+          </DataTable.Title>
+          <DataTable.Title
+            accessibilityStates={[]}
+            style={{ paddingRight: 10 }}
+            numeric
+          >
+            Value
+          </DataTable.Title>
+          <DataTable.Title accessibilityStates={[]}>Units</DataTable.Title>
+          <DataTable.Title accessibilityStates={[]}>Time</DataTable.Title>
+        </DataTable.Header>
+        {bloodGlucoseSamples
+          ? bloodGlucoseSamples.map((sample: HKQuantitySample) => (
+              <DisplayQuantitySample sample={sample} title="Glucose" />
+            ))
+          : null}
       </DataTable>
     </ScrollView>
   );
@@ -269,9 +299,9 @@ function DataView() {
 
 /*
 
-                
-        
-        
+
+
+
       </DataTable>*/
 
 const App = () => {
@@ -288,6 +318,7 @@ const App = () => {
         HKQuantityTypeIdentifier.bodyMass,
         HKQuantityTypeIdentifier.heartRate,
         HKQuantityTypeIdentifier.bloodGlucose,
+        HKQuantityTypeIdentifier.insulinDelivery,
         HKQuantityTypeIdentifier.activeEnergyBurned,
         HKCategoryTypeIdentifier.mindfulSession,
         HKQuantityTypeIdentifier.dietaryCaffeine,
@@ -298,6 +329,7 @@ const App = () => {
         HKQuantityTypeIdentifier.waistCircumference,
         HKQuantityTypeIdentifier.activeEnergyBurned,
         HKQuantityTypeIdentifier.bloodGlucose,
+        HKQuantityTypeIdentifier.insulinDelivery,
         HKQuantityTypeIdentifier.bodyFatPercentage,
         HKCategoryTypeIdentifier.mindfulSession,
         HKQuantityTypeIdentifier.dietaryCaffeine,

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -794,7 +794,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
     }
 
     @objc(queryWorkoutSamples:distanceUnitString:from:to:limit:ascending:resolve:reject:)
-    func queryWorkoutSamples(energyUnitString: String, distanceUnitString: String, from: Date, to: Date, limit: Int, ascending: NSNumber, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
+    func queryWorkoutSamples(energyUnitString: String, distanceUnitString: String, from: Date, to: Date, limit: Int, ascending: Bool, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
@@ -809,7 +809,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
         let energyUnit = HKUnit.init(from: energyUnitString)
         let distanceUnit = HKUnit.init(from: distanceUnitString)
         
-        let q = HKSampleQuery(sampleType: .workoutType(), predicate: predicate, limit: limit, sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: Bool(truncating: ascending))]) { (query: HKSampleQuery, sample: [HKSample]?, error: Error?) in
+        let q = HKSampleQuery(sampleType: .workoutType(), predicate: predicate, limit: limit, sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: ascending)]) { (query: HKSampleQuery, sample: [HKSample]?, error: Error?) in
             guard let err = error else {
                 guard let samples = sample else {
                     return resolve([]);
@@ -851,7 +851,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
     
     
     @objc(queryQuantitySamples:unitString:from:to:limit:ascending:resolve:reject:)
-    func queryQuantitySamples(typeIdentifier: String, unitString: String, from: Date, to: Date, limit: Int, ascending: NSNumber, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
+    func queryQuantitySamples(typeIdentifier: String, unitString: String, from: Date, to: Date, limit: Int, ascending: Bool, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
@@ -868,7 +868,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
         
         let limit = limit == 0 ? HKObjectQueryNoLimit : limit;
         
-        let q = HKSampleQuery(sampleType: sampleType, predicate: predicate, limit: limit, sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: Bool(truncating: ascending))]) { (query: HKSampleQuery, sample: [HKSample]?, error: Error?) in
+        let q = HKSampleQuery(sampleType: sampleType, predicate: predicate, limit: limit, sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: ascending)]) { (query: HKSampleQuery, sample: [HKSample]?, error: Error?) in
             guard let err = error else {
                 guard let samples = sample else {
                     return resolve([]);
@@ -958,7 +958,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
     }
     
     @objc(queryCategorySamples:from:to:limit:ascending:resolve:reject:)
-    func queryCategorySamples(typeIdentifier: String, from: Date, to: Date, limit: Int, ascending: NSNumber, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
+    func queryCategorySamples(typeIdentifier: String, from: Date, to: Date, limit: Int, ascending: Bool, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
@@ -975,7 +975,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
         
         let limit = limit == 0 ? HKObjectQueryNoLimit : limit;
         
-        let q = HKSampleQuery(sampleType: sampleType, predicate: predicate, limit: limit, sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: Bool(truncating: ascending))]) { (query: HKSampleQuery, sample: [HKSample]?, error: Error?) in
+        let q = HKSampleQuery(sampleType: sampleType, predicate: predicate, limit: limit, sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: ascending)]) { (query: HKSampleQuery, sample: [HKSample]?, error: Error?) in
             guard let err = error else {
                 guard let samples = sample else {
                     return resolve([]);


### PR DESCRIPTION
Hi!

First of all – thank you for this library, it's by far the most complete and straightforward HealthKit library for React Native.

I've faced the issue described here: https://github.com/Kingstinct/react-native-healthkit/issues/2
Any call to the queryQuantitySamples with the ascending parameter set to true ended up with a crash on type conversion.

I'm not very familiar with ObjC and Swift, but it seems that changing the swift method signature (making ascending argument Bool) helps.

What do you think?
