### PR TITLE
feat: add sourceRevision info to HK samples

### DIFF
--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -225,7 +225,8 @@ class ReactNativeHealthkit: RCTEventEmitter {
             "startDate": startDate,
             "quantity": quantity,
             "unit": unit.unitString,
-            "metadata": self.serializeMetadata(metadata: sample.metadata)
+            "metadata": self.serializeMetadata(metadata: sample.metadata),
+            "sourceRevision": self.serializeSourceRevision(_sourceRevision: sample.sourceRevision) as Any,
         ]
     }
     
@@ -240,7 +241,8 @@ class ReactNativeHealthkit: RCTEventEmitter {
             "endDate": endDate,
             "startDate": startDate,
             "value": sample.value,
-            "metadata": self.serializeMetadata(metadata: sample.metadata)
+            "metadata": self.serializeMetadata(metadata: sample.metadata),
+            "sourceRevision": self.serializeSourceRevision(_sourceRevision: sample.sourceRevision) as Any,
         ]
     }
     
@@ -792,6 +794,37 @@ class ReactNativeHealthkit: RCTEventEmitter {
             "softwareVersion": device.softwareVersion,
         ]
     }
+    
+    func serializeOperatingSystemVersion(_version: OperatingSystemVersion?) -> String? {
+        guard let version = _version else {
+            return nil;
+        }
+        
+        let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)";
+        
+        return versionString;
+    }
+    
+    func serializeSourceRevision(_sourceRevision: HKSourceRevision?) -> Dictionary<String, Any?>? {
+        guard let sourceRevision = _sourceRevision else {
+            return nil;
+        }
+        
+        var dict = [
+            "source": [
+                "name": sourceRevision.source.name,
+                "bundleIdentifier": sourceRevision.source.bundleIdentifier
+            ],
+            "version": sourceRevision.version
+        ] as [String : Any];
+        
+        if #available(iOS 11, *) {
+            dict["operatingSystemVersion"] = self.serializeOperatingSystemVersion(_version: sourceRevision.operatingSystemVersion);
+            dict["productType"] = sourceRevision.productType;
+        }
+        
+        return dict;
+    }
 
     @objc(queryWorkoutSamples:distanceUnitString:from:to:limit:ascending:resolve:reject:)
     func queryWorkoutSamples(energyUnitString: String, distanceUnitString: String, from: Date, to: Date, limit: Int, ascending: Bool, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
@@ -830,7 +863,8 @@ class ReactNativeHealthkit: RCTEventEmitter {
                             "workoutActivityType": workout.workoutActivityType.rawValue,
                             "startDate": startDate,
                             "endDate": endDate,
-                            "metadata": self.serializeMetadata(metadata: workout.metadata)
+                            "metadata": self.serializeMetadata(metadata: workout.metadata),
+                            "sourceRevision": self.serializeSourceRevision(_sourceRevision: workout.sourceRevision) as Any
                         ]
                         
                         if #available(iOS 11, *) {

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -559,6 +559,18 @@ export type HKDevice = {
   softwareVersion: string;
 };
 
+export type HKSource = {
+  name: string;
+  bundleIdentifier: string;
+};
+
+export type HKSourceRevision = {
+  source: HKSource;
+  version: string;
+  operatingSystemVersion?: string;
+  productType?: string;
+};
+
 export type HKQuantitySampleRaw<
   TQuantityIdentifier extends HKQuantityTypeIdentifier = HKQuantityTypeIdentifier,
   TUnit extends HKUnit = HKUnit
@@ -571,6 +583,7 @@ export type HKQuantitySampleRaw<
   quantity: number;
   unit: TUnit;
   metadata: MetadataMapperForQuantityIdentifier<TQuantityIdentifier>;
+  sourceRevision?: HKSourceRevision;
 };
 
 export type HKWorkoutRaw<TEnergy extends HKUnit, TDistance extends HKUnit> = {
@@ -583,6 +596,7 @@ export type HKWorkoutRaw<TEnergy extends HKUnit, TDistance extends HKUnit> = {
   startDate: string;
   endDate: string;
   metadata?: HKWorkoutMetadata;
+  sourceRevision?: HKSourceRevision;
 };
 
 // Straight mapping to https://developer.apple.com/documentation/healthkit/hkcharacteristictypeidentifier
@@ -618,6 +632,7 @@ export type HKCategorySampleRaw<
   endDate: string;
   value: HKCategoryValueForIdentifier<T>;
   metadata: MetadataMapperForCategoryIdentifier<T>;
+  sourceRevision?: HKSourceRevision;
 };
 
 export type HKCorrelationRaw<


### PR DESCRIPTION
Hi,

I'm in the process of migrating from the other React Native HealthKit library, and I've found that source info for HK samples is missing.

Added this to quantity, category, and workout samples. Tried to stick as close to the native types as possible.