### PR TITLE
Fix compilation error for react-native 0.64

### DIFF
--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -29,6 +29,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
         if(HKHealthStore.isHealthDataAvailable()){
             self._store = HKHealthStore.init();
         }
+        super.init();
     }
     
     deinit {


### PR DESCRIPTION
When updating to react native 0.64.0 pod does not compile after `RCTEventEmitter` added
```objc
- (instancetype)initWithDisabledObservation;
```
[here](https://github.com/facebook/react-native/commit/82187bfb6b54fdffc5dadaa56e8bf97d2209708a#diff-3215dd761992f420e8effa738d5ce9c03a0977b9d85b87f15529394265755912R19)

![Screenshot 2021-05-02 at 12 01 09](https://user-images.githubusercontent.com/232147/116809821-d4232480-ab48-11eb-9f07-2112f000ec37.png)

This should fix it.