### PR TITLE
remove combine

### DIFF
--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -1,5 +1,4 @@
 import HealthKit;
-import Combine;
 
 let INIT_ERROR = "HEALTHKIT_INIT_ERROR"
 let INIT_ERROR_MESSAGE = "HealthKit not initialized"


### PR DESCRIPTION
An archive build fails with error "no such module combine". Combine is currently not needed and only available for [iOS 13+ ](https://developer.apple.com/documentation/combine)and can be removed.