### PR TITLE
fix: fixed mismatched objc method signatures between .m and .swift files

### DIFF
--- a/ios/ReactNativeHealthkit.m
+++ b/ios/ReactNativeHealthkit.m
@@ -29,7 +29,7 @@ RCT_EXTERN_METHOD(getBloodType:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(getDateOfBirth:(RCTPromiseResolveBlock)resolve
-withRejecter:(RCTPromiseRejectBlock)reject)
+                  withRejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(authorizationStatusFor:(NSString)typeIdentifier
                   withResolver:(RCTPromiseResolveBlock)resolve
@@ -37,19 +37,19 @@ RCT_EXTERN_METHOD(authorizationStatusFor:(NSString)typeIdentifier
 
 RCT_EXTERN_METHOD(enableBackgroundDelivery:(NSString)typeIdentifier
                   updateFrequency:(NSInteger)updateFrequency
-                  withResolver:(RCTPromiseResolveBlock)resolve
-                  withRejecter:(RCTPromiseRejectBlock)reject);
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(disableBackgroundDelivery:(NSString)typeIdentifier
-withResolver:(RCTPromiseResolveBlock)resolve
-withRejecter:(RCTPromiseRejectBlock)reject);
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(disableAllBackgroundDelivery:(RCTPromiseResolveBlock)resolve
-withRejecter:(RCTPromiseRejectBlock)reject);
+                  reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(getPreferredUnits:(NSArray)forIdentifiers
-resolve:(RCTPromiseResolveBlock)resolve
-reject:(RCTPromiseRejectBlock)reject)
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 
 
 RCT_EXTERN_METHOD(saveQuantitySample:(NSString)typeIdentifier
@@ -145,6 +145,6 @@ RCT_EXTERN_METHOD(queryStatisticsForQuantity:(NSString)typeIdentifier
 )
 
 RCT_EXTERN_METHOD(getWheelchairUse:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  withRejecter:(RCTPromiseRejectBlock)reject)
 
 @end


### PR DESCRIPTION
Fix for #19 
I changed the signatures in ReactNativeHealthkit.m to match ReactNativeHealthkit.swift.
I didn't try to make them consistent since I wasn't sure about the project's naming preference.
