### PR TITLE
feat: add support for workout locations

### DIFF
--- a/ios/ReactNativeHealthkit.m
+++ b/ios/ReactNativeHealthkit.m
@@ -147,7 +147,7 @@ RCT_EXTERN_METHOD(queryStatisticsForQuantity:(NSString)typeIdentifier
 RCT_EXTERN_METHOD(getWheelchairUse:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getWorkoutLocations:(NSString)workoutUUID
+RCT_EXTERN_METHOD(getWorkoutRoutes:(NSString)workoutUUID
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject
 )

--- a/ios/ReactNativeHealthkit.m
+++ b/ios/ReactNativeHealthkit.m
@@ -85,7 +85,7 @@ RCT_EXTERN_METHOD(queryWorkoutSamples:(NSString)energyUnitString
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject
 )
-    
+
 RCT_EXTERN_METHOD(queryCategorySamples:(NSString)typeIdentifier
                   from:(NSDate)from
                   to:(NSDate)to
@@ -146,5 +146,10 @@ RCT_EXTERN_METHOD(queryStatisticsForQuantity:(NSString)typeIdentifier
 
 RCT_EXTERN_METHOD(getWheelchairUse:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getWorkoutLocations:(NSString)workoutUUID
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject
+)
 
 @end

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -16,6 +16,11 @@ let HKWorkoutTypeIdentifier = "HKWorkoutTypeIdentifier"
 let HKWorkoutRouteTypeIdentifier = "HKWorkoutRouteTypeIdentifier"
 let HKDataTypeIdentifierHeartbeatSeries = "HKDataTypeIdentifierHeartbeatSeries"
 
+// HKUnit.meter().unitDivided(by: HKUnit.second())
+let HKSpeedUnit =  HKUnit(from: "m/s")
+// Support for MET data, eg: HKAverageMETs 8.24046 kcal/hr·kg
+let HKMETUnit = HKUnit(from: "kcal/hr·kg")
+
 
 @objc(ReactNativeHealthkit)
 @available(iOS 10.0, *)
@@ -768,6 +773,15 @@ class ReactNativeHealthkit: RCTEventEmitter {
                 return self.serializeQuantity(unit: HKUnit.decibelHearingLevel(), quantity: quantity);
             }
         }
+
+        if(quantity.is(compatibleWith: HKSpeedUnit)){
+            return self.serializeQuantity(unit: HKSpeedUnit, quantity: quantity);
+        }
+
+        if(quantity.is(compatibleWith: HKMETUnit)){
+            return self.serializeQuantity(unit: HKMETUnit, quantity: quantity);
+        }
+
         return nil;
     }
 

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -1,17 +1,21 @@
 import HealthKit;
+import CoreLocation;
 
 let INIT_ERROR = "HEALTHKIT_INIT_ERROR"
 let INIT_ERROR_MESSAGE = "HealthKit not initialized"
 let TYPE_IDENTIFIER_ERROR = "HEALTHKIT_TYPE_IDENTIFIER_NOT_RECOGNIZED_ERROR"
-let GENERIC_ERROR = "HEALTHKIT_ERROR";
+let GENERIC_ERROR = "HEALTHKIT_ERROR"
 
 let HKCharacteristicTypeIdentifier_PREFIX = "HKCharacteristicTypeIdentifier"
 let HKQuantityTypeIdentifier_PREFIX = "HKQuantityTypeIdentifier"
 let HKCategoryTypeIdentifier_PREFIX = "HKCategoryTypeIdentifier"
 let HKCorrelationTypeIdentifier_PREFIX = "HKCorrelationTypeIdentifier"
 let HKActivitySummaryTypeIdentifier = "HKActivitySummaryTypeIdentifier"
-let HKAudiogramTypeIdentifier = "HKAudiogramTypeIdentifier";
+let HKAudiogramTypeIdentifier = "HKAudiogramTypeIdentifier"
 let HKWorkoutTypeIdentifier = "HKWorkoutTypeIdentifier"
+let HKWorkoutRouteTypeIdentifier = "HKWorkoutRouteTypeIdentifier"
+let HKDataTypeIdentifierHeartbeatSeries = "HKDataTypeIdentifierHeartbeatSeries"
+
 
 @objc(ReactNativeHealthkit)
 @available(iOS 10.0, *)
@@ -20,17 +24,17 @@ class ReactNativeHealthkit: RCTEventEmitter {
     var _runningQueries : Dictionary<String, HKQuery>;
     var _dateFormatter : ISO8601DateFormatter;
     var _hasListeners = false
-    
+
     override init() {
         self._runningQueries = Dictionary<String, HKQuery>();
         self._dateFormatter = ISO8601DateFormatter();
-        
+
         if(HKHealthStore.isHealthDataAvailable()){
             self._store = HKHealthStore.init();
         }
         super.init();
     }
-    
+
     deinit {
         if let store = _store {
                 for query in self._runningQueries {
@@ -38,7 +42,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
                 }
         }
     }
-    
+
     override func stopObserving() -> Void {
         self._hasListeners = false
         if let store = _store {
@@ -47,78 +51,88 @@ class ReactNativeHealthkit: RCTEventEmitter {
                 }
         }
     }
-    
+
     override func startObserving() -> Void {
         self._hasListeners = true
     }
-    
+
     func objectTypeFromString(typeIdentifier: String) -> HKObjectType? {
         if(typeIdentifier.starts(with: HKCharacteristicTypeIdentifier_PREFIX)){
             let identifier = HKCharacteristicTypeIdentifier.init(rawValue: typeIdentifier);
             return HKObjectType.characteristicType(forIdentifier: identifier) as HKObjectType?
         }
-        
+
         if(typeIdentifier.starts(with: HKQuantityTypeIdentifier_PREFIX)){
             let identifier = HKQuantityTypeIdentifier.init(rawValue: typeIdentifier);
             return HKObjectType.quantityType(forIdentifier: identifier) as HKObjectType?
         }
-        
+
         if(typeIdentifier.starts(with: HKCategoryTypeIdentifier_PREFIX)){
             let identifier = HKCategoryTypeIdentifier.init(rawValue: typeIdentifier);
             return HKObjectType.categoryType(forIdentifier: identifier) as HKObjectType?
         }
-        
+
         if(typeIdentifier.starts(with: HKCorrelationTypeIdentifier_PREFIX)){
             let identifier = HKCorrelationTypeIdentifier.init(rawValue: typeIdentifier);
             return HKObjectType.correlationType(forIdentifier: identifier) as HKObjectType?
         }
-        
+
         if(typeIdentifier == HKActivitySummaryTypeIdentifier){
             return HKObjectType.activitySummaryType();
         }
-        
+
         if #available(iOS 13, *) {
             if(typeIdentifier == HKAudiogramTypeIdentifier){
                 return HKObjectType.audiogramSampleType();
             }
+
+            if(typeIdentifier == HKDataTypeIdentifierHeartbeatSeries){
+                return HKObjectType.seriesType(forIdentifier: typeIdentifier);
+            }
         }
-        
+
         if(typeIdentifier == HKWorkoutTypeIdentifier){
             return HKObjectType.workoutType()
         }
-        
+
+        if #available(iOS 11.0, *){
+            if typeIdentifier == HKWorkoutRouteTypeIdentifier{
+                return HKObjectType.seriesType(forIdentifier: typeIdentifier);
+            }
+        }
+
         return nil;
     }
-    
+
     func sampleTypeFromString(typeIdentifier: String) -> HKSampleType? {
         if(typeIdentifier.starts(with: HKQuantityTypeIdentifier_PREFIX)){
             let identifier = HKQuantityTypeIdentifier.init(rawValue: typeIdentifier);
             return HKSampleType.quantityType(forIdentifier: identifier) as HKSampleType?
         }
-        
+
         if(typeIdentifier.starts(with: HKCategoryTypeIdentifier_PREFIX)){
             let identifier = HKCategoryTypeIdentifier.init(rawValue: typeIdentifier);
             return HKSampleType.categoryType(forIdentifier: identifier) as HKSampleType?
         }
-        
+
         if(typeIdentifier.starts(with: HKCorrelationTypeIdentifier_PREFIX)){
             let identifier = HKCorrelationTypeIdentifier.init(rawValue: typeIdentifier);
             return HKSampleType.correlationType(forIdentifier: identifier) as HKSampleType?
         }
-        
+
         if #available(iOS 13, *) {
             if(typeIdentifier == HKAudiogramTypeIdentifier){
                 return HKSampleType.audiogramSampleType();
             }
         }
-        
+
         if(typeIdentifier == HKWorkoutTypeIdentifier){
             return HKSampleType.workoutType();
         }
-        
+
         return nil;
     }
-    
+
     func objectTypesFromDictionary(typeIdentifiers: NSDictionary) -> Set<HKObjectType> {
         var share = Set<HKObjectType>();
         for item in typeIdentifiers {
@@ -131,7 +145,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
         }
         return share;
     }
-    
+
     func sampleTypesFromDictionary(typeIdentifiers: NSDictionary) -> Set<HKSampleType> {
         var share = Set<HKSampleType>();
         for item in typeIdentifiers {
@@ -144,12 +158,12 @@ class ReactNativeHealthkit: RCTEventEmitter {
         }
         return share;
     }
-    
+
     @objc(isHealthDataAvailable:withRejecter:)
     func isHealthDataAvailable(resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
         resolve(HKHealthStore.isHealthDataAvailable())
     }
-    
+
     @available(iOS 12.0, *)
     @objc(supportsHealthRecords:withRejecter:)
     func supportsHealthRecords(resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
@@ -158,7 +172,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
         }
         resolve(store.supportsHealthRecords());
     }
-    
+
     @available(iOS 12.0, *)
     @objc(getRequestStatusForAuthorization:read:resolve:withRejecter:)
     func getRequestStatusForAuthorization(toShare: NSDictionary, read: NSDictionary, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
@@ -174,7 +188,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, err.localizedDescription, err);
         }
     }
-    
+
     @objc(getPreferredUnits:resolve:reject:)
     func getPreferredUnits(forIdentifiers: NSArray, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
@@ -188,35 +202,35 @@ class ReactNativeHealthkit: RCTEventEmitter {
                 quantityTypes.insert(type!);
             }
         }
-        
+
         store.preferredUnits(for: quantityTypes) { (typePerUnits: [HKQuantityType : HKUnit], error: Error?) in
             let dic: NSMutableDictionary = NSMutableDictionary();
-            
+
             for typePerUnit in typePerUnits {
                 dic.setObject(typePerUnit.value.unitString, forKey: typePerUnit.key.identifier as NSCopying);
             }
-            
+
             resolve(dic);
         }
     }
-    
+
     func serializeQuantity(unit: HKUnit, quantity: HKQuantity?) -> Dictionary<String, Any>? {
         guard let q = quantity else {
             return nil;
         }
-        
+
         return [
             "quantity": q.doubleValue(for: unit),
             "unit": unit.unitString
         ]
     }
-    
+
     func serializeQuantitySample(sample: HKQuantitySample, unit: HKUnit) -> NSDictionary {
         let endDate = _dateFormatter.string(from: sample.endDate)
         let startDate = _dateFormatter.string(from: sample.startDate);
-        
+
         let quantity = sample.quantity.doubleValue(for: unit);
-        
+
         return [
             "uuid": sample.uuid.uuidString,
             "device": self.serializeDevice(_device: sample.device),
@@ -229,11 +243,11 @@ class ReactNativeHealthkit: RCTEventEmitter {
             "sourceRevision": self.serializeSourceRevision(_sourceRevision: sample.sourceRevision) as Any,
         ]
     }
-    
+
     func serializeCategorySample(sample: HKCategorySample) -> NSDictionary {
         let endDate = _dateFormatter.string(from: sample.endDate)
         let startDate = _dateFormatter.string(from: sample.startDate);
-        
+
         return [
             "uuid": sample.uuid.uuidString,
             "device": self.serializeDevice(_device: sample.device),
@@ -245,13 +259,13 @@ class ReactNativeHealthkit: RCTEventEmitter {
             "sourceRevision": self.serializeSourceRevision(_sourceRevision: sample.sourceRevision) as Any,
         ]
     }
-    
+
     @objc(getBiologicalSex:withRejecter:)
     func getBiologicalSex(resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         do {
             let bioSex = try store.biologicalSex();
             resolve(bioSex.biologicalSex.rawValue);
@@ -259,13 +273,13 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, error.localizedDescription, error);
         }
     }
-    
+
     @objc(getDateOfBirth:withRejecter:)
     func getDateOfBirth(resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         do {
             let dateOfBirth = try store.dateOfBirth();
             resolve(_dateFormatter.string(from: dateOfBirth));
@@ -273,13 +287,13 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, error.localizedDescription, error);
         }
     }
-    
+
     @objc(getBloodType:withRejecter:)
     func getBloodType(resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         do {
             let bloodType = try store.bloodType();
             resolve(bloodType.bloodType.rawValue);
@@ -287,13 +301,13 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, error.localizedDescription, error);
         }
     }
-    
+
     @objc(getFitzpatrickSkinType:withRejecter:)
     func getFitzpatrickSkinType(resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         do {
             let fitzpatrickSkinType = try store.fitzpatrickSkinType();
             resolve(fitzpatrickSkinType.skinType.rawValue);
@@ -301,15 +315,15 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, error.localizedDescription, error);
         }
     }
-    
-    
+
+
     @available(iOS 10.0, *)
     @objc(getWheelchairUse:withRejecter:)
     func getWheelchairUse(resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         do {
             let wheelchairUse = try store.wheelchairUse();
             resolve(wheelchairUse.wheelchairUse.rawValue);
@@ -317,29 +331,29 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, error.localizedDescription, error);
         }
     }
-    
+
     @objc(authorizationStatusFor:withResolver:withRejecter:)
     func authorizationStatusFor(typeIdentifier: String, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         guard let objectType = objectTypeFromString(typeIdentifier: typeIdentifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
-        
+
         let authStatus = store.authorizationStatus(for: objectType);
         resolve(authStatus.rawValue);
     }
-    
+
     @objc(saveQuantitySample:unitString:value:start:end:metadata:resolve:reject:)
     func saveQuantitySample(typeIdentifier: String, unitString: String, value: Double, start: Date, end: Date, metadata: Dictionary<String, Any>, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         let identifier = HKQuantityTypeIdentifier.init(rawValue: typeIdentifier);
-        
+
         guard let type = HKObjectType.quantityType(forIdentifier: identifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
@@ -361,19 +375,19 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, err.localizedDescription, error);
         }
     }
-    
+
     @objc(saveCorrelationSample:samples:start:end:metadata:resolve:reject:)
     func saveCorrelationSample(typeIdentifier: String, samples: Array<Dictionary<String, Any>>, start: Date, end: Date, metadata: Dictionary<String, Any>, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         let identifier = HKCorrelationTypeIdentifier.init(rawValue: typeIdentifier);
-        
+
         guard let type = HKObjectType.correlationType(forIdentifier: identifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
-        
+
         var initializedSamples = Set<HKSample>();
         for sample in samples {
             if(sample.keys.contains("quantityType")){
@@ -382,7 +396,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
                     let unitStr = sample["unit"] as! String
                     let quantityVal = sample["quantity"] as! Double
                     let metadata = sample["metadata"] as? [String: Any]
-                    
+
                     let unit = HKUnit.init(from: unitStr)
                     let quantity = HKQuantity.init(unit: unit, doubleValue: quantityVal)
                     let quantitySample = HKQuantitySample.init(type: type, quantity: quantity, start: start, end: end, metadata: metadata)
@@ -393,16 +407,16 @@ class ReactNativeHealthkit: RCTEventEmitter {
                if let type = HKSampleType.categoryType(forIdentifier: typeId) {
                    let value = sample["value"] as! Int
                    let metadata = sample["metadata"] as? [String: Any]
-                   
+
                    let categorySample = HKCategorySample.init(type: type, value: value, start: start, end: end, metadata: metadata)
                    initializedSamples.insert(categorySample);
                }
             }
-            
+
         }
-        
+
         let correlation = HKCorrelation.init(type: type, start: start, end: end, objects: initializedSamples, metadata: metadata)
-        
+
         store.save(correlation) { (success: Bool, error: Error?) in
             guard let err = error else {
                 return resolve(success);
@@ -410,30 +424,30 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, err.localizedDescription, error);
         }
     }
-    
+
     @objc(saveWorkoutSample:quantities:start:end:metadata:resolve:reject:)
     func saveWorkoutSample(typeIdentifier: UInt, quantities: Array<Dictionary<String, Any>>, start: Date, end: Date, metadata: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         guard let type = HKWorkoutActivityType.init(rawValue: typeIdentifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier.description, nil);
         }
-        
+
         var initializedSamples = [HKSample]();
         var totalEnergyBurned: HKQuantity?
         var totalDistance: HKQuantity?
         var totalSwimmingStrokeCount: HKQuantity?
         var totalFlightsClimbed: HKQuantity?
-        
+
         for quantity in quantities {
             let typeId = HKQuantityTypeIdentifier.init(rawValue: quantity["quantityType"] as! String)
             if let type = HKSampleType.quantityType(forIdentifier: typeId) {
                 let unitStr = quantity["unit"] as! String
                 let quantityVal = quantity["quantity"] as! Double
                 let metadata = quantity["metadata"] as? [String: Any]
-                
+
                 let unit = HKUnit.init(from: unitStr)
                 let quantity = HKQuantity.init(unit: unit, doubleValue: quantityVal)
                 if(quantity.is(compatibleWith: HKUnit.kilocalorie())){
@@ -452,10 +466,10 @@ class ReactNativeHealthkit: RCTEventEmitter {
                 initializedSamples.append(quantitySample)
             }
         }
-        
+
         var workout: HKWorkout?;
-        
-        
+
+
         if(totalSwimmingStrokeCount != nil){
             workout = HKWorkout.init(activityType: type, start: start, end: end, workoutEvents: nil, totalEnergyBurned: totalEnergyBurned, totalDistance: totalDistance, totalSwimmingStrokeCount: totalSwimmingStrokeCount, device: nil, metadata: metadata)
         } else {
@@ -465,11 +479,11 @@ class ReactNativeHealthkit: RCTEventEmitter {
                     }
                 }
         }
-        
+
         if(workout == nil){
             workout = HKWorkout.init(activityType: type, start: start, end: end, workoutEvents: nil, totalEnergyBurned: totalEnergyBurned, totalDistance: totalDistance, metadata: metadata)
         }
-        
+
         store.save(workout!) { (success: Bool, error: Error?) in
             guard let err = error else {
                 if(success){
@@ -485,24 +499,24 @@ class ReactNativeHealthkit: RCTEventEmitter {
             }
             reject(GENERIC_ERROR, err.localizedDescription, error);
         }
-        
-        
+
+
     }
-    
+
     @objc(saveCategorySample:value:start:end:metadata:resolve:reject:)
     func saveCategorySample(typeIdentifier: String, value: Int, start: Date, end: Date, metadata: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         let identifier = HKCategoryTypeIdentifier.init(rawValue: typeIdentifier);
-        
+
         guard let type = HKObjectType.categoryType(forIdentifier: identifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
 
         let sample = HKCategorySample.init(type: type, value: value, start: start, end: end, metadata: metadata as? Dictionary<String, Any>)
-        
+
         store.save(sample) { (success: Bool, error: Error?) in
             guard let err = error else {
                 return resolve(success);
@@ -510,25 +524,25 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, err.localizedDescription, error);
         }
     }
-    
+
     override func supportedEvents() -> [String]! {
       return ["onChange"]
     }
-    
+
     @objc(enableBackgroundDelivery:updateFrequency:resolve:reject:)
     func enableBackgroundDelivery(typeIdentifier: String, updateFrequency: Int, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         guard let sampleType = objectTypeFromString(typeIdentifier: typeIdentifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
-        
+
         guard let frequency = HKUpdateFrequency.init(rawValue: updateFrequency) else {
             return reject("UpdateFrequency not valid", "UpdateFrequency not valid", nil);
         }
-        
+
         store.enableBackgroundDelivery(for: sampleType, frequency:frequency ) { (success, error) in
             guard let err = error else {
                 return resolve(success);
@@ -536,13 +550,13 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, err.localizedDescription, err);
         }
     }
-    
+
     @objc(disableAllBackgroundDelivery:reject:)
     func disableAllBackgroundDelivery(resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         store.disableAllBackgroundDelivery(completion: { (success, error) in
             guard let err = error else {
                 return resolve(success);
@@ -550,18 +564,18 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, err.localizedDescription, err);
         })
     }
-    
+
     @objc(disableBackgroundDelivery:resolve:reject:)
     func disableBackgroundDelivery(typeIdentifier: String, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         guard let sampleType = objectTypeFromString(typeIdentifier: typeIdentifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
-        
-        
+
+
         store.disableBackgroundDelivery(for: sampleType) { (success, error) in
             guard let err = error else {
                 return resolve(success);
@@ -569,21 +583,21 @@ class ReactNativeHealthkit: RCTEventEmitter {
             reject(GENERIC_ERROR, err.localizedDescription, err);
         }
     }
-    
+
     @objc(subscribeToObserverQuery:resolve:reject:)
     func subscribeToObserverQuery(typeIdentifier: String, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         guard let sampleType = sampleTypeFromString(typeIdentifier: typeIdentifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
-        
+
         let predicate = HKQuery.predicateForSamples(withStart: Date.init(), end: nil, options: HKQueryOptions.strictStartDate)
-        
+
         let queryId = UUID().uuidString
-        
+
         func responder(query: HKObserverQuery, handler: @escaping HKObserverQueryCompletionHandler, error: Error?) -> Void {
             if(error == nil){
                 DispatchQueue.main.async {
@@ -592,62 +606,62 @@ class ReactNativeHealthkit: RCTEventEmitter {
                             "typeIdentifier": typeIdentifier,
                         ]);
                     }
-                    
+
                 }
                 handler();
             }
         }
-        
+
         let query = HKObserverQuery(sampleType: sampleType, predicate: predicate) { (query: HKObserverQuery, handler: @escaping HKObserverQueryCompletionHandler, error: Error?) in
             guard let err = error else {
                 return responder(query: query, handler: handler, error: error);
             }
             reject(GENERIC_ERROR, err.localizedDescription, err);
         }
-        
+
         store.execute(query);
-        
+
         self._runningQueries.updateValue(query, forKey: queryId);
     }
-    
+
     @objc(unsubscribeQuery:resolve:reject:)
     func unsubscribeQuery(queryId: String, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         guard let query = self._runningQueries[queryId] else {
             reject("Error", "Query with id " + queryId + " not found", nil);
             return;
         }
-        
+
         store.stop(query);
-        
+
         self._runningQueries.removeValue(forKey: queryId);
-        
+
         resolve(true);
     }
-    
+
 
     static override func requiresMainQueueSetup() -> Bool {
         return true
     }
-    
+
     @objc(queryStatisticsForQuantity:unitString:from:to:options:resolve:reject:)
     func queryStatisticsForQuantity(typeIdentifier: String, unitString: String, from: Date, to: Date, options: NSArray, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         let identifier = HKQuantityTypeIdentifier.init(rawValue: typeIdentifier);
         guard let quantityType = HKObjectType.quantityType(forIdentifier: identifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
-        
+
         let predicate = HKQuery.predicateForSamples(withStart: from, end: to, options: HKQueryOptions.strictEndDate)
-        
+
         var opts = HKStatisticsOptions.init();
-        
+
         for o in options {
             let str = o as! String;
             if(str == "cumulativeSum"){
@@ -674,12 +688,12 @@ class ReactNativeHealthkit: RCTEventEmitter {
                     opts.insert(HKStatisticsOptions.mostRecent)
                 }
             }
-            
+
             if(str == "separateBySource"){
                 opts.insert(HKStatisticsOptions.separateBySource)
             }
         }
-        
+
         let query = HKStatisticsQuery.init(quantityType: quantityType, quantitySamplePredicate: predicate, options: opts) { (query, stats: HKStatistics?, error: Error?) in
             if let gottenStats = stats {
                 var dic = Dictionary<String, Dictionary<String, Any>?>()
@@ -700,7 +714,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
                     if let mostRecent = gottenStats.mostRecentQuantity() {
                         dic.updateValue(self.serializeQuantity(unit: unit, quantity: mostRecent), forKey: "mostRecentQuantity")
                     }
-                    
+
                     if let mostRecentDateInterval = gottenStats.mostRecentQuantityDateInterval() {
                         dic.updateValue([
                             "start": self._dateFormatter.string(from: mostRecentDateInterval.start),
@@ -714,38 +728,38 @@ class ReactNativeHealthkit: RCTEventEmitter {
                         dic.updateValue(self.serializeQuantity(unit: durationUnit, quantity: duration), forKey: "duration")
                     }
                 }
-                
+
                 resolve(dic);
             }
         }
-        
+
         store.execute(query);
     }
-    
+
     func serializeUnknownQuantity(quantity: HKQuantity) -> Dictionary<String, Any>? {
         if(quantity.is(compatibleWith: HKUnit.percent())){
             return self.serializeQuantity(unit: HKUnit.percent(), quantity: quantity);
         }
-        
-        
+
+
         if(quantity.is(compatibleWith: HKUnit.second())){
             return self.serializeQuantity(unit: HKUnit.second(), quantity: quantity);
         }
-        
+
         if(quantity.is(compatibleWith: HKUnit.kilocalorie())){
             return self.serializeQuantity(unit: HKUnit.kilocalorie(), quantity: quantity);
         }
-        
+
         if(quantity.is(compatibleWith: HKUnit.count())){
             return self.serializeQuantity(unit: HKUnit.count(), quantity: quantity)
         }
-        
+
         if #available(iOS 11, *) {
             if(quantity.is(compatibleWith: HKUnit.internationalUnit())){
                 return self.serializeQuantity(unit: HKUnit.internationalUnit(), quantity: quantity);
             }
         }
-        
+
         if #available(iOS 13, *) {
             if(quantity.is(compatibleWith: HKUnit.hertz())){
                 return self.serializeQuantity(unit: HKUnit.hertz(), quantity: quantity);
@@ -756,7 +770,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
         }
         return nil;
     }
-    
+
     func serializeMetadata(metadata: [String: Any]?) -> NSDictionary {
         let serialized: NSMutableDictionary = [:];
         if let m = metadata {
@@ -779,7 +793,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
         }
         return serialized;
     }
-    
+
     func serializeDevice(_device: HKDevice?) -> Dictionary<String, String?>? {
         guard let device = _device else {
             return nil;
@@ -794,22 +808,22 @@ class ReactNativeHealthkit: RCTEventEmitter {
             "softwareVersion": device.softwareVersion,
         ]
     }
-    
+
     func serializeOperatingSystemVersion(_version: OperatingSystemVersion?) -> String? {
         guard let version = _version else {
             return nil;
         }
-        
+
         let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)";
-        
+
         return versionString;
     }
-    
+
     func serializeSourceRevision(_sourceRevision: HKSourceRevision?) -> Dictionary<String, Any?>? {
         guard let sourceRevision = _sourceRevision else {
             return nil;
         }
-        
+
         var dict = [
             "source": [
                 "name": sourceRevision.source.name,
@@ -817,12 +831,12 @@ class ReactNativeHealthkit: RCTEventEmitter {
             ],
             "version": sourceRevision.version
         ] as [String : Any];
-        
+
         if #available(iOS 11, *) {
             dict["operatingSystemVersion"] = self.serializeOperatingSystemVersion(_version: sourceRevision.operatingSystemVersion);
             dict["productType"] = sourceRevision.productType;
         }
-        
+
         return dict;
     }
 
@@ -831,24 +845,24 @@ class ReactNativeHealthkit: RCTEventEmitter {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         let from = from.timeIntervalSince1970 > 0 ? from : nil;
         let to = to.timeIntervalSince1970 > 0 ? to : nil;
-        
+
         let predicate = from != nil || to != nil ? HKQuery.predicateForSamples(withStart: from, end: to, options: [HKQueryOptions.strictEndDate, HKQueryOptions.strictStartDate]) : nil;
-        
+
         let limit = limit == 0 ? HKObjectQueryNoLimit : limit;
-        
+
         let energyUnit = HKUnit.init(from: energyUnitString)
         let distanceUnit = HKUnit.init(from: distanceUnitString)
-        
+
         let q = HKSampleQuery(sampleType: .workoutType(), predicate: predicate, limit: limit, sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: ascending)]) { (query: HKSampleQuery, sample: [HKSample]?, error: Error?) in
             guard let err = error else {
                 guard let samples = sample else {
                     return resolve([]);
                 }
                 let arr: NSMutableArray = [];
-                
+
                 for s in samples {
                     if let workout = s as? HKWorkout {
                         let endDate = self._dateFormatter.string(from: workout.endDate)
@@ -866,87 +880,87 @@ class ReactNativeHealthkit: RCTEventEmitter {
                             "metadata": self.serializeMetadata(metadata: workout.metadata),
                             "sourceRevision": self.serializeSourceRevision(_sourceRevision: workout.sourceRevision) as Any
                         ]
-                        
+
                         if #available(iOS 11, *) {
                             dict.setValue(self.serializeQuantity(unit: HKUnit.count(), quantity: workout.totalFlightsClimbed), forKey: "totalFlightsClimbed")
                         }
-                        
+
                         arr.add(dict)
                     }
                 }
-                
+
                 return resolve(arr);
             }
             reject(GENERIC_ERROR, err.localizedDescription, err);
         }
-        
+
         store.execute(q);
     }
-    
-    
+
+
     @objc(queryQuantitySamples:unitString:from:to:limit:ascending:resolve:reject:)
     func queryQuantitySamples(typeIdentifier: String, unitString: String, from: Date, to: Date, limit: Int, ascending: Bool, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         let identifier = HKQuantityTypeIdentifier.init(rawValue: typeIdentifier);
         guard let sampleType = HKSampleType.quantityType(forIdentifier: identifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
-        
+
         let from = from.timeIntervalSince1970 > 0 ? from : nil;
         let to = to.timeIntervalSince1970 > 0 ? to : nil;
-        
+
         let predicate = from != nil || to != nil ? HKQuery.predicateForSamples(withStart: from, end: to, options: [HKQueryOptions.strictEndDate, HKQueryOptions.strictStartDate]) : nil;
-        
+
         let limit = limit == 0 ? HKObjectQueryNoLimit : limit;
-        
+
         let q = HKSampleQuery(sampleType: sampleType, predicate: predicate, limit: limit, sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: ascending)]) { (query: HKSampleQuery, sample: [HKSample]?, error: Error?) in
             guard let err = error else {
                 guard let samples = sample else {
                     return resolve([]);
                 }
                 let arr: NSMutableArray = [];
-                
+
                 for s in samples {
                     if let sample = s as? HKQuantitySample {
                         let serialized = self.serializeQuantitySample(sample: sample, unit: HKUnit.init(from: unitString))
-                        
+
                         arr.add(serialized)
                     }
                 }
-                
+
                 return resolve(arr);
             }
             reject(GENERIC_ERROR, err.localizedDescription, err);
         }
-        
+
         store.execute(q);
     }
-    
+
     @objc(queryCorrelationSamples:from:to:resolve:reject:)
     func queryCorrelationSamples(typeIdentifier: String, from: Date, to: Date, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         let identifier = HKCorrelationTypeIdentifier.init(rawValue: typeIdentifier);
         guard let sampleType = HKSampleType.correlationType(forIdentifier: identifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
-        
+
         let from = from.timeIntervalSince1970 > 0 ? from : nil;
         let to = to.timeIntervalSince1970 > 0 ? to : nil;
-        
+
         let predicate = from != nil || to != nil ? HKQuery.predicateForSamples(withStart: from, end: to, options: [HKQueryOptions.strictEndDate, HKQueryOptions.strictStartDate]) : nil;
-        
+
         let q = HKCorrelationQuery(type: sampleType, predicate: predicate, samplePredicates: nil) { (query: HKCorrelationQuery, _correlations: [HKCorrelation]?, error: Error?) in
             guard let err = error else {
                 guard let correlations = _correlations else {
                     return resolve([]);
                 }
-                
+
                 var qts = Set<HKQuantityType>();
                 for c in correlations {
                     for object in c.objects {
@@ -968,7 +982,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
                                     objects.add(self.serializeCategorySample(sample: categorySample))
                                 }
                             }
-                            
+
                             collerationsToReturn.add([
                                 "uuid": c.uuid.uuidString,
                                 "device": self.serializeDevice(_device: c.device) as Any,
@@ -979,7 +993,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
                                 "endDate": self._dateFormatter.string(from: c.endDate),
                             ])
                         }
-                        
+
                         return resolve(collerationsToReturn);
                     }
                     reject(GENERIC_ERROR, e.localizedDescription, e);
@@ -987,65 +1001,221 @@ class ReactNativeHealthkit: RCTEventEmitter {
             }
             reject(GENERIC_ERROR, err.localizedDescription, err);
         }
-        
+
         store.execute(q);
     }
-    
+
     @objc(queryCategorySamples:from:to:limit:ascending:resolve:reject:)
     func queryCategorySamples(typeIdentifier: String, from: Date, to: Date, limit: Int, ascending: Bool, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         let identifier = HKCategoryTypeIdentifier.init(rawValue: typeIdentifier);
         guard let sampleType = HKSampleType.categoryType(forIdentifier: identifier) else {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
-        
+
         let from = from.timeIntervalSince1970 > 0 ? from : nil;
         let to = to.timeIntervalSince1970 > 0 ? to : nil;
-        
+
         let predicate = from != nil || to != nil ? HKQuery.predicateForSamples(withStart: from, end: to, options: [HKQueryOptions.strictEndDate, HKQueryOptions.strictStartDate]) : nil;
-        
+
         let limit = limit == 0 ? HKObjectQueryNoLimit : limit;
-        
+
         let q = HKSampleQuery(sampleType: sampleType, predicate: predicate, limit: limit, sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: ascending)]) { (query: HKSampleQuery, sample: [HKSample]?, error: Error?) in
             guard let err = error else {
                 guard let samples = sample else {
                     return resolve([]);
                 }
                 let arr: NSMutableArray = [];
-                
+
                 for s in samples {
                     if let sample = s as? HKCategorySample {
                         let serialized = self.serializeCategorySample(sample: sample);
-                        
+
                         arr.add(serialized)
                     }
                 }
-                
+
                 return resolve(arr);
             }
             reject(GENERIC_ERROR, err.localizedDescription, err);
         }
-        
+
         store.execute(q);
     }
-    
+
     @objc(requestAuthorization:read:resolve:withRejecter:)
     func requestAuthorization(toShare: NSDictionary, read: NSDictionary, resolve: @escaping RCTPromiseResolveBlock,reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
-        
+
         let share = sampleTypesFromDictionary(typeIdentifiers: toShare);
         let toRead = objectTypesFromDictionary(typeIdentifiers: read);
-        
+
         store.requestAuthorization(toShare: share, read: toRead) { (success: Bool, error: Error?) in
             guard let err = error else {
                 return resolve(success);
             }
             reject(GENERIC_ERROR, err.localizedDescription, err);
+        }
+    }
+
+    @available(iOS 13.0.0, *)
+    func getWorkoutByID(store: HKHealthStore,
+                        workoutUUID: UUID) async -> HKWorkout? {
+        let workoutPredicate = HKQuery.predicateForObject(with: workoutUUID);
+
+        let samples = try! await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<[HKSample], Error>) in
+                let query = HKAnchoredObjectQuery(type: HKSeriesType.workoutType(),
+                                                predicate: workoutPredicate,
+                                                anchor: nil,
+                                                limit: 1) {
+                (query, samples, deletedObjects, anchor, error) in
+
+                if let hasError = error {
+                    continuation.resume(throwing: hasError)
+                    return
+                }
+
+                guard let samples = samples else {
+                    fatalError("Should not fail")
+                }
+
+                continuation.resume(returning: samples)
+            }
+            store.execute(query)
+        }
+
+        guard let workouts = samples as? [HKWorkout] else {
+            return nil
+        }
+
+        return workouts.first ?? nil
+    }
+
+
+    @available(iOS 13.0.0, *)
+    func _getWorkoutRoutes(store: HKHealthStore, workoutUUID: UUID) async -> [HKWorkoutRoute]?{
+        guard let workout = await getWorkoutByID(store: store, workoutUUID: workoutUUID) else {
+            return nil
+        }
+
+        let workoutPredicate = HKQuery.predicateForObjects(from: workout)
+        let samples = try! await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<[HKSample], Error>) in
+                let query = HKAnchoredObjectQuery(type: HKSeriesType.workoutRoute(),
+                                                predicate: workoutPredicate,
+                                                anchor: nil,
+                                                limit: HKObjectQueryNoLimit) {
+                (query, samples, deletedObjects, anchor, error) in
+
+                if let hasError = error {
+                    continuation.resume(throwing: hasError)
+                    return
+                }
+
+                guard let samples = samples else {
+                    fatalError("Should not fail")
+                }
+
+                continuation.resume(returning: samples)
+            }
+            store.execute(query)
+        }
+
+        guard let routes = samples as? [HKWorkoutRoute] else {
+            return nil
+        }
+
+        return routes
+    }
+
+    @available(iOS 13.0.0, *)
+    func getRouteLocations(store: HKHealthStore, route: HKWorkoutRoute) async -> [CLLocation] {
+        let locations = try! await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<[CLLocation], Error>) in
+            var allLocations: [CLLocation] = []
+
+            let query = HKWorkoutRouteQuery(route: route) {
+                (query, locationsOrNil, done, errorOrNil) in
+
+                if let error = errorOrNil {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                guard let currentLocationBatch = locationsOrNil else {
+                    fatalError("Should not fail")
+                }
+
+                allLocations.append(contentsOf: currentLocationBatch)
+
+                if done {
+                    continuation.resume(returning: allLocations)
+                }
+            }
+
+            store.execute(query)
+        }
+
+        return locations
+    }
+
+    @available(iOS 13.0.0, *)
+    func getSerializedWorkoutLocations(store: HKHealthStore, workoutUUID: UUID) async -> [[NSDictionary]]? {
+        let routes = await _getWorkoutRoutes(store: store, workoutUUID: workoutUUID)
+
+        var allLocations: [[NSDictionary]] = []
+        guard let _routes = routes else {
+            return nil
+        }
+        for route in _routes {
+            let routeLocations = await getRouteLocations(store: store, route: route)
+            allLocations.append(routeLocations.map{serializeLocation(location: $0)})
+        }
+        return allLocations
+    }
+
+    func serializeLocation(location: CLLocation) -> NSDictionary {
+        return [
+            "longitude": location.coordinate.longitude,
+            "latitude": location.coordinate.latitude,
+            "altitude": location.altitude,
+            "speed": location.speed,
+            "timestamp": location.timestamp.timeIntervalSince1970,
+            "horizontalAccuracy": location.horizontalAccuracy,
+            "speedAccuracy": location.speedAccuracy,
+            "verticalAccuracy": location.verticalAccuracy,
+        ]
+    }
+
+    @available(iOS 13.0.0, *)
+    @objc(getWorkoutLocations:resolve:reject:)
+    func getWorkoutLocations(
+        workoutUUID: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock){
+
+        guard let store = _store else {
+            return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil)
+        }
+
+        guard let _workoutUUID = UUID(uuidString: workoutUUID) else {
+            return reject("INVALID_UUID_ERROR", "Invalid UUID received", nil)
+        }
+
+        async {
+            do {
+                let locations = await getSerializedWorkoutLocations(store: store, workoutUUID: _workoutUUID)
+                resolve(locations)
+            }
+            catch {
+                reject("FAILED_RETRIEVE_WORKOUT_LOC", "Failed to retrieve workout location", nil)
+            }
         }
     }
 }

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -1213,8 +1213,8 @@ class ReactNativeHealthkit: RCTEventEmitter {
     }
 
     @available(iOS 13.0.0, *)
-    @objc(getWorkoutLocations:resolve:reject:)
-    func getWorkoutLocations(
+    @objc(getWorkoutRoutes:resolve:reject:)
+    func getWorkoutRoutes(
         workoutUUID: String,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock){

--- a/src/index.ios.tsx
+++ b/src/index.ios.tsx
@@ -23,7 +23,7 @@ import type {
   GetMostRecentWorkoutFn,
   GetPreferredUnitFn,
   GetPreferredUnitsFn,
-  GetWorkoutLocationsFn,
+  GetWorkoutRoutesFn,
   HKCategorySample,
   HKCorrelation,
   HKQuantitySample,
@@ -530,8 +530,8 @@ const saveWorkoutSample: SaveWorkoutSampleFn = (
   );
 };
 
-const getWorkoutLocations: GetWorkoutLocationsFn = (workoutUUID: string) => {
-  return Native.getWorkoutLocations(workoutUUID);
+const getWorkoutRoutes: GetWorkoutRoutesFn = (workoutUUID: string) => {
+  return Native.getWorkoutRoutes(workoutUUID);
 };
 
 const Healthkit: ReactNativeHealthkit = {
@@ -560,7 +560,7 @@ const Healthkit: ReactNativeHealthkit = {
   getPreferredUnits,
   getRequestStatusForAuthorization,
 
-  getWorkoutLocations,
+  getWorkoutRoutes,
 
   // query methods
   queryCategorySamples,

--- a/src/index.ios.tsx
+++ b/src/index.ios.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Native, {
   EventEmitter,
   HKCategorySampleRaw,
@@ -23,6 +23,7 @@ import type {
   GetMostRecentWorkoutFn,
   GetPreferredUnitFn,
   GetPreferredUnitsFn,
+  GetWorkoutLocationsFn,
   HKCategorySample,
   HKCorrelation,
   HKQuantitySample,
@@ -529,6 +530,10 @@ const saveWorkoutSample: SaveWorkoutSampleFn = (
   );
 };
 
+const getWorkoutLocations: GetWorkoutLocationsFn = (workoutUUID: string) => {
+  return Native.getWorkoutLocations(workoutUUID);
+};
+
 const Healthkit: ReactNativeHealthkit = {
   authorizationStatusFor: Native.authorizationStatusFor,
 
@@ -554,6 +559,8 @@ const Healthkit: ReactNativeHealthkit = {
   getPreferredUnit,
   getPreferredUnits,
   getRequestStatusForAuthorization,
+
+  getWorkoutLocations,
 
   // query methods
   queryCategorySamples,
@@ -582,7 +589,7 @@ const Healthkit: ReactNativeHealthkit = {
   useSubscribeToChanges,
 };
 
-export * from './types';
 export * from './native-types';
+export * from './types';
 
 export default Healthkit;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ const Healthkit: ReactNativeHealthkit = {
   getPreferredUnits: UnavailableFn,
   getRequestStatusForAuthorization: UnavailableFn,
   getWheelchairUse: UnavailableFn,
-  getWorkoutLocations: UnavailableFn,
+  getWorkoutRoutes: UnavailableFn,
   isHealthDataAvailable: () => Promise.resolve(false),
   queryCategorySamples: UnavailableFn,
   queryCorrelationSamples: UnavailableFn,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ const Healthkit: ReactNativeHealthkit = {
   getPreferredUnits: UnavailableFn,
   getRequestStatusForAuthorization: UnavailableFn,
   getWheelchairUse: UnavailableFn,
+  getWorkoutLocations: UnavailableFn,
   isHealthDataAvailable: () => Promise.resolve(false),
   queryCategorySamples: UnavailableFn,
   queryCorrelationSamples: UnavailableFn,
@@ -45,7 +46,7 @@ const Healthkit: ReactNativeHealthkit = {
   useSubscribeToChanges: UnavailableFn,
 };
 
-export * from './types';
 export * from './native-types';
+export * from './types';
 
 export default Healthkit;

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -1,7 +1,7 @@
 import {
-  NativeModules,
-  NativeEventEmitter,
   EmitterSubscription,
+  NativeEventEmitter,
+  NativeModules,
 } from 'react-native';
 
 export type HKWorkoutTypeIdentifier = 'HKWorkoutTypeIdentifier';
@@ -295,6 +295,12 @@ export enum HKAuthorizationRequestStatus {
   unknown = 0,
   shouldRequest = 1,
   unnecessary = 2,
+}
+
+export enum HKAuthorizationStatus {
+  notDetermined = 0,
+  sharingDenied = 1,
+  sharingAuthorized = 2,
 }
 
 export type HKQuantity<T extends HKUnit = HKUnit> = {
@@ -666,6 +672,17 @@ export enum HKUpdateFrequency {
   weekly = 4,
 }
 
+export type WorkoutLocation = {
+  longitude: number;
+  latitude: number;
+  altitude: number;
+  speed: number;
+  timestamp: number;
+  horizontalAccuracy: number;
+  speedAccuracy: number;
+  verticalAccuracy: number;
+};
+
 type ReactNativeHealthkitTypeNative = {
   isHealthDataAvailable(): Promise<boolean>;
   getBloodType(): Promise<HKBloodType>;
@@ -777,6 +794,7 @@ type ReactNativeHealthkitTypeNative = {
   getPreferredUnits: (
     identifiers: HKQuantityTypeIdentifier[]
   ) => Promise<TypeToUnitMapping>;
+  getWorkoutLocations: (workoutUUID: string) => Promise<WorkoutLocation[][]>;
 };
 
 const Native =

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -683,6 +683,12 @@ export type WorkoutLocation = {
   verticalAccuracy: number;
 };
 
+export type WorkoutRoute = {
+  locations: WorkoutLocation[];
+  HKMetadataKeySyncIdentifier?: string;
+  HKMetadataKeySyncVersion?: number;
+};
+
 type ReactNativeHealthkitTypeNative = {
   isHealthDataAvailable(): Promise<boolean>;
   getBloodType(): Promise<HKBloodType>;
@@ -794,7 +800,7 @@ type ReactNativeHealthkitTypeNative = {
   getPreferredUnits: (
     identifiers: HKQuantityTypeIdentifier[]
   ) => Promise<TypeToUnitMapping>;
-  getWorkoutLocations: (workoutUUID: string) => Promise<WorkoutLocation[][]>;
+  getWorkoutRoutes: (workoutUUID: string) => Promise<WorkoutRoute[]>;
 };
 
 const Native =

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ import type {
   MetadataMapperForCorrelationIdentifier,
   MetadataMapperForQuantityIdentifier,
   QueryStatisticsResponseRaw,
-  WorkoutLocation,
+  WorkoutRoute,
 } from './native-types';
 
 export interface QueryWorkoutsOptions<
@@ -269,9 +269,9 @@ export type SubscribeToChangesHook = <
   runInitialUpdate?: boolean
 ) => void;
 
-export type GetWorkoutLocationsFn = (
+export type GetWorkoutRoutesFn = (
   workoutUUID: string
-) => Promise<WorkoutLocation[][]>;
+) => Promise<WorkoutRoute[]>;
 
 export type ReactNativeHealthkit = {
   authorizationStatusFor: AuthorizationStatusForFn;
@@ -287,7 +287,7 @@ export type ReactNativeHealthkit = {
   getPreferredUnits: GetPreferredUnitsFn;
   getRequestStatusForAuthorization: GetRequestStatusForAuthorizationFn;
   getWheelchairUse: GetWheelchairUseFn;
-  getWorkoutLocations: GetWorkoutLocationsFn;
+  getWorkoutRoutes: GetWorkoutRoutesFn;
 
   buildUnitWithPrefix: (prefix: HKUnitSIPrefix, unit: HKUnitSI) => HKUnit;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,6 @@ import type {
   HKCorrelationRaw,
   HKCorrelationTypeIdentifier,
   HKFitzpatrickSkinType,
-  MetadataMapperForCategoryIdentifier,
   HKQuantitySampleRaw,
   HKQuantityTypeIdentifier,
   HKSampleTypeIdentifier,
@@ -17,14 +16,16 @@ import type {
   HKUnit,
   HKUnitSI,
   HKUnitSIPrefix,
+  HKUpdateFrequency,
   HKWheelchairUse,
   HKWorkoutActivityType,
   HKWorkoutMetadata,
   HKWorkoutRaw,
+  MetadataMapperForCategoryIdentifier,
   MetadataMapperForCorrelationIdentifier,
   MetadataMapperForQuantityIdentifier,
   QueryStatisticsResponseRaw,
-  HKUpdateFrequency,
+  WorkoutLocation,
 } from './native-types';
 
 export interface QueryWorkoutsOptions<
@@ -268,6 +269,10 @@ export type SubscribeToChangesHook = <
   runInitialUpdate?: boolean
 ) => void;
 
+export type GetWorkoutLocationsFn = (
+  workoutUUID: string
+) => Promise<WorkoutLocation[][]>;
+
 export type ReactNativeHealthkit = {
   authorizationStatusFor: AuthorizationStatusForFn;
 
@@ -282,6 +287,7 @@ export type ReactNativeHealthkit = {
   getPreferredUnits: GetPreferredUnitsFn;
   getRequestStatusForAuthorization: GetRequestStatusForAuthorizationFn;
   getWheelchairUse: GetWheelchairUseFn;
+  getWorkoutLocations: GetWorkoutLocationsFn;
 
   buildUnitWithPrefix: (prefix: HKUnitSIPrefix, unit: HKUnitSI) => HKUnit;
 


### PR DESCRIPTION
Hi, 

I saw that the library was missing the possibility to get locations from a workout so here is a proposed solution. 
I'm no swift expert at all so feel free to correct anything.

The new function outputs an locations as a nested array of locations
```json
[[{
    "altitude": 111.11080169677734,
    "horizontalAccuracy": 11.250052452087402,
    "latitude": 48.79551754488684,
    "longitude": 2.29879251611046,
    "speed": 0.07861018180847168,
    "speedAccuracy": 1.1210601329803467,
    "timestamp": 1654723528.0003781,
    "verticalAccuracy": 1.3213047981262207
}]]
```