### PR TITLE
fix: double conversion

### DIFF
--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -507,7 +507,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
     }
 
     @objc(saveCategorySample:value:start:end:metadata:resolve:reject:)
-    func saveCategorySample(typeIdentifier: String, value: Int, start: Date, end: Date, metadata: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock){
+    func saveCategorySample(typeIdentifier: String, value: Double, start: Date, end: Date, metadata: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
         }
@@ -518,7 +518,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
             return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
         }
 
-        let sample = HKCategorySample.init(type: type, value: value, start: start, end: end, metadata: metadata as? Dictionary<String, Any>)
+        let sample = HKCategorySample.init(type: type, value: Int(value), start: start, end: end, metadata: metadata as? Dictionary<String, Any>)
 
         store.save(sample) { (success: Bool, error: Error?) in
             guard let err = error else {


### PR DESCRIPTION
While testing out the library I noticed that when saving sleep the HKCategoryValue seems not to work in the case of sleep, but instead every sleep values is saved as `inBed` even if it was `asleep`. Explicitly converting the Double value to Int in `saveCategorySample` on Swift side seems to fix this.

Now I'm no Swift expert, so perhaps there is a better way to do this? I didn't also test it with all the possible  HKCategoryValues so might be that change breaks something?