### PR TITLE
Adding canAccessProtectedData utils , fix EventEmitter

### DIFF
--- a/android/.project
+++ b/android/.project
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>android_</name>
+	<name>kingstinct_react-native-healthkit</name>
 	<comment>Project android_ created by Buildship.</comment>
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 		<buildCommand>
 			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
 			<arguments>
@@ -12,6 +17,18 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1663745272821</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,11 +1,11 @@
-arguments=
+arguments=--init-script /var/folders/lb/4fb2wm497wq1_0vknwt43h3h0000gn/T/init5242912127258488867.gradle --init-script /var/folders/lb/4fb2wm497wq1_0vknwt43h3h0000gn/T/init4373878353927339792.gradle
 auto.sync=false
 build.scans.enabled=false
-connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(6.0))
-connection.project.dir=
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(7.4.2))
+connection.project.dir=../example/android
 eclipse.preferences.version=1
 gradle.user.home=
-java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home
+java.home=/Users/andarius/.sdkman/candidates/java/11.0.2-open
 jvm.arguments=
 offline.mode=false
 override.workspace.settings=true

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -74,7 +74,7 @@ PODS:
   - fmt (6.2.1)
   - glog (0.3.5)
   - hermes-engine (0.11.0)
-  - kingstinct-react-native-healthkit (4.4.6):
+  - kingstinct-react-native-healthkit (5.1.1):
     - React
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
@@ -554,7 +554,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
   hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
-  kingstinct-react-native-healthkit: 8a6964341ed4d7189d57bdeb98cff1a6a7727bf5
+  kingstinct-react-native-healthkit: caaf2433704c7ec60583e5055fddf810947f31f5
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,9 @@
 /* eslint-disable import/no-unresolved */
-import {
-  HKStatisticsOptions, HKQuantityTypeIdentifier, HKAuthorizationRequestStatus, HKWorkoutActivityType,
+import Healthkit, {
+  HKAuthorizationRequestStatus,
+  HKQuantityTypeIdentifier,
+  HKStatisticsOptions,
+  HKWorkoutActivityType,
 } from '@kingstinct/react-native-healthkit'
 import useHealthkitAuthorization from '@kingstinct/react-native-healthkit/hooks/useHealthkitAuthorization'
 import useMostRecentQuantitySample from '@kingstinct/react-native-healthkit/hooks/useMostRecentQuantitySample'
@@ -11,116 +14,175 @@ import saveQuantitySample from '@kingstinct/react-native-healthkit/utils/saveQua
 import saveWorkoutSample from '@kingstinct/react-native-healthkit/utils/saveWorkoutSample'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { ScrollView, StyleSheet, View } from 'react-native'
 import {
-  Button, List, Menu, TextInput, Provider,
+  Button,
+  List,
+  Menu,
+  Provider,
+  Text,
+  TextInput,
 } from 'react-native-paper'
 
-import type { HKUnit, HealthkitReadAuthorization, HealthkitWriteAuthorization } from '@kingstinct/react-native-healthkit'
+import type {
+  HealthkitReadAuthorization,
+  HealthkitWriteAuthorization,
+  HKUnit,
+} from '@kingstinct/react-native-healthkit'
 import type { ComponentProps } from 'react'
 import type { IconSource } from 'react-native-paper/lib/typescript/components/Icon'
 
 dayjs.extend(relativeTime)
 
 const LatestListItem: React.FC<{
-  readonly identifier: HKQuantityTypeIdentifier,
-  readonly unit?: HKUnit
-  readonly icon: IconSource
-  readonly title: string
+  readonly identifier: HKQuantityTypeIdentifier;
+  readonly unit?: HKUnit;
+  readonly icon: IconSource;
+  readonly title: string;
 }> = ({
   identifier, unit, title, icon,
 }) => {
   const latestValue = useMostRecentQuantitySample(identifier, unit),
-        left = useCallback((props: Omit<ComponentProps<typeof List.Icon>, 'icon'>) => <List.Icon {...props} icon={icon} />, [icon])
+        left = useCallback(
+          (props: Omit<ComponentProps<typeof List.Icon>, 'icon'>) => (
+            <List.Icon {...props} icon={icon} />
+          ),
+          [icon],
+        )
 
   return (
     <List.Item
       title={title || identifier}
       left={left}
-      description={latestValue
-        ? `${latestValue.unit === '%' ? (latestValue.quantity * 100).toFixed(1) : latestValue.quantity.toFixed(latestValue.unit === 'count' || latestValue.unit === 'count/min' ? 0 : 2)} ${latestValue.unit} (${dayjs(latestValue.endDate).fromNow()})`
-        : 'No data found'}
+      description={
+        latestValue
+          ? `${
+            latestValue.unit === '%'
+              ? (latestValue.quantity * 100).toFixed(1)
+              : latestValue.quantity.toFixed(
+                latestValue.unit === 'count'
+                      || latestValue.unit === 'count/min'
+                  ? 0
+                  : 2,
+              )
+          } ${latestValue.unit} (${dayjs(latestValue.endDate).fromNow()})`
+          : 'No data found'
+      }
     />
   )
 }
 
 const LatestWorkout: React.FC<{
-  readonly icon: IconSource
-  readonly title: string
-}> = ({
-  title, icon,
-}) => {
+  readonly icon: IconSource;
+  readonly title: string;
+}> = ({ title, icon }) => {
   const latestValue = useMostRecentWorkout(),
-        left = useCallback((props: Omit<ComponentProps<typeof List.Icon>, 'icon'>) => <List.Icon {...props} icon={icon} />, [icon])
+        left = useCallback(
+          (props: Omit<ComponentProps<typeof List.Icon>, 'icon'>) => (
+            <List.Icon {...props} icon={icon} />
+          ),
+          [icon],
+        )
 
   return (
     <List.Accordion title='Latest workout' id='workout'>
       <List.Item
         title={title}
         left={left}
-        description={latestValue
-          ? `${TRANSLATED_WORKOUT_TYPES_TO_SHOW[latestValue.workoutActivityType as WorkoutType] ?? `Untranslated workout type (${latestValue.workoutActivityType})`} (${dayjs(latestValue.endDate).fromNow()})`
-          : 'No data found'}
+        description={
+          latestValue
+            ? `${
+              TRANSLATED_WORKOUT_TYPES_TO_SHOW[
+                latestValue.workoutActivityType as WorkoutType
+              ]
+                ?? `Untranslated workout type (${latestValue.workoutActivityType})`
+            } (${dayjs(latestValue.endDate).fromNow()})`
+            : 'No data found'
+        }
       />
       <List.Item
         title='Distance'
         // eslint-disable-next-line react/no-unstable-nested-components
         left={(props) => <List.Icon {...props} icon='map-marker-distance' />}
-        description={latestValue?.totalDistance
-          ? `${latestValue.totalDistance.quantity.toFixed(2)} ${latestValue.totalDistance.unit}`
-          : 'No data found'}
+        description={
+          latestValue?.totalDistance
+            ? `${latestValue.totalDistance.quantity.toFixed(2)} ${
+              latestValue.totalDistance.unit
+            }`
+            : 'No data found'
+        }
       />
       <List.Item
         title='Energy'
         // eslint-disable-next-line react/no-unstable-nested-components
         left={(props) => <List.Icon {...props} icon='fire' />}
-        description={latestValue?.totalEnergyBurned
-          ? `${latestValue.totalEnergyBurned.quantity.toFixed(0)} ${latestValue.totalEnergyBurned.unit}`
-          : 'No data found'}
+        description={
+          latestValue?.totalEnergyBurned
+            ? `${latestValue.totalEnergyBurned.quantity.toFixed(0)} ${
+              latestValue.totalEnergyBurned.unit
+            }`
+            : 'No data found'
+        }
       />
       <List.Item
         title='Metadata'
         // eslint-disable-next-line react/no-unstable-nested-components
         left={(props) => <List.Icon {...props} icon='database' />}
-        description={latestValue?.metadata
-          ? `${JSON.stringify(latestValue.metadata)}`
-          : 'No data found'}
+        description={
+          latestValue?.metadata
+            ? `${JSON.stringify(latestValue.metadata)}`
+            : 'No data found'
+        }
       />
       <List.Item
         title='Device'
         // eslint-disable-next-line react/no-unstable-nested-components
         left={(props) => <List.Icon {...props} icon='watch' />}
-        description={latestValue?.device
-          ? `${latestValue.device.name}`
-          : 'No data found'}
+        description={
+          latestValue?.device ? `${latestValue.device.name}` : 'No data found'
+        }
       />
     </List.Accordion>
   )
 }
 
 const TodayListItem: React.FC<{
-  readonly identifier: HKQuantityTypeIdentifier,
-  readonly unit: HKUnit,
-  readonly title: string,
-  readonly icon: IconSource
-  readonly option: HKStatisticsOptions
+  readonly identifier: HKQuantityTypeIdentifier;
+  readonly unit: HKUnit;
+  readonly title: string;
+  readonly icon: IconSource;
+  readonly option: HKStatisticsOptions;
 }> = ({
   identifier, option, unit, title, icon,
 }) => {
-  const latestValue = useStatisticsForQuantity(identifier, [option], dayjs().startOf('day').toDate(), undefined, unit),
-        left = useCallback((props: Omit<ComponentProps<typeof List.Icon>, 'icon'>) => <List.Icon {...props} icon={icon} />, [icon])
+  const latestValue = useStatisticsForQuantity(
+          identifier,
+          [option],
+          dayjs().startOf('day').toDate(),
+          undefined,
+          unit,
+        ),
+        left = useCallback(
+          (props: Omit<ComponentProps<typeof List.Icon>, 'icon'>) => (
+            <List.Icon {...props} icon={icon} />
+          ),
+          [icon],
+        )
 
   return (
     <List.Item
       title={title}
       left={left}
-      description={latestValue
-        ? `${latestValue.sumQuantity?.unit === 'count'
-          ? latestValue.sumQuantity?.quantity
-          : latestValue.sumQuantity?.quantity.toFixed(2)
-        } (${latestValue.sumQuantity?.unit})`
-        : 'No data found'}
+      description={
+        latestValue
+          ? `${
+            latestValue.sumQuantity?.unit === 'count'
+              ? latestValue.sumQuantity?.quantity
+              : latestValue.sumQuantity?.quantity.toFixed(2)
+          } (${latestValue.sumQuantity?.unit})`
+          : 'No data found'
+      }
     />
   )
 }
@@ -215,10 +277,12 @@ const TRANSLATED_WORKOUT_TYPES_TO_SHOW = {
   [HKWorkoutActivityType.walking]: 'Walking',
 }
 
-type WorkoutType = keyof typeof TRANSLATED_WORKOUT_TYPES_TO_SHOW
+type WorkoutType = keyof typeof TRANSLATED_WORKOUT_TYPES_TO_SHOW;
 
 const SaveWorkout = () => {
-  const [typeToSave, setTypeToSave] = useState<WorkoutType>(HKWorkoutActivityType.americanFootball)
+  const [typeToSave, setTypeToSave] = useState<WorkoutType>(
+    HKWorkoutActivityType.americanFootball,
+  )
   const [menuVisible, setMenuVisible] = useState<boolean>(false)
   const [kcalStr, setkcalStr] = useState<string>('50')
   const [distanceMetersStr, setDistanceMetersStr] = useState<string>('1000')
@@ -226,19 +290,28 @@ const SaveWorkout = () => {
   const save = useCallback(() => {
     const val = parseFloat(kcalStr)
     const distance = parseFloat(distanceMetersStr)
-    if (val !== undefined && !Number.isNaN(val) && distance !== undefined && !Number.isNaN(distance)) {
-      void saveWorkoutSample(typeToSave, [
-        {
-          quantity: distance,
-          unit: 'm',
-          quantityType: HKQuantityTypeIdentifier.distanceWalkingRunning,
-        },
-        {
-          quantity: val,
-          unit: 'kcal',
-          quantityType: HKQuantityTypeIdentifier.activeEnergyBurned,
-        },
-      ], new Date())
+    if (
+      val !== undefined
+      && !Number.isNaN(val)
+      && distance !== undefined
+      && !Number.isNaN(distance)
+    ) {
+      void saveWorkoutSample(
+        typeToSave,
+        [
+          {
+            quantity: distance,
+            unit: 'm',
+            quantityType: HKQuantityTypeIdentifier.distanceWalkingRunning,
+          },
+          {
+            quantity: val,
+            unit: 'kcal',
+            quantityType: HKQuantityTypeIdentifier.activeEnergyBurned,
+          },
+        ],
+        new Date(),
+      )
       setkcalStr('0')
     }
   }, [kcalStr, typeToSave, distanceMetersStr])
@@ -248,20 +321,26 @@ const SaveWorkout = () => {
       <Menu
         visible={menuVisible}
         onDismiss={() => setMenuVisible(false)}
-        anchor={<Button uppercase={false} onPress={() => setMenuVisible(true)}>{TRANSLATED_WORKOUT_TYPES_TO_SHOW[typeToSave]}</Button>}
+        anchor={(
+          <Button uppercase={false} onPress={() => setMenuVisible(true)}>
+            {TRANSLATED_WORKOUT_TYPES_TO_SHOW[typeToSave]}
+          </Button>
+        )}
       >
-        {
-          Object.keys(TRANSLATED_WORKOUT_TYPES_TO_SHOW).map((type) => (
-            <Menu.Item
-              key={type}
-              onPress={() => {
-                setTypeToSave(parseInt(type, 10) as WorkoutType)
-                setMenuVisible(false)
-              }}
-              title={TRANSLATED_WORKOUT_TYPES_TO_SHOW[type as unknown as WorkoutType] ?? `Untranslated workout type (${type})`}
-            />
-          ))
-        }
+        {Object.keys(TRANSLATED_WORKOUT_TYPES_TO_SHOW).map((type) => (
+          <Menu.Item
+            key={type}
+            onPress={() => {
+              setTypeToSave(parseInt(type, 10) as WorkoutType)
+              setMenuVisible(false)
+            }}
+            title={
+              TRANSLATED_WORKOUT_TYPES_TO_SHOW[
+                type as unknown as WorkoutType
+              ] ?? `Untranslated workout type (${type})`
+            }
+          />
+        ))}
       </Menu>
       <TextInput
         accessibilityLabel='Value'
@@ -312,7 +391,9 @@ const DeleteQuantity = () => {
 }
 
 const SaveQuantity = () => {
-  const [typeToSave, setTypeToSave] = useState<HKQuantityTypeIdentifier>(HKQuantityTypeIdentifier.stepCount)
+  const [typeToSave, setTypeToSave] = useState<HKQuantityTypeIdentifier>(
+    HKQuantityTypeIdentifier.stepCount,
+  )
   const [menuVisible, setMenuVisible] = useState<boolean>(false)
   const [saveValueStr, setSaveValueStr] = useState<string>('0')
 
@@ -337,20 +418,22 @@ const SaveQuantity = () => {
       <Menu
         visible={menuVisible}
         onDismiss={() => setMenuVisible(false)}
-        anchor={<Button uppercase={false} onPress={() => setMenuVisible(true)}>{typeToSave.replace('HKQuantityTypeIdentifier', '')}</Button>}
+        anchor={(
+          <Button uppercase={false} onPress={() => setMenuVisible(true)}>
+            {typeToSave.replace('HKQuantityTypeIdentifier', '')}
+          </Button>
+        )}
       >
-        {
-          [...saveableCountTypes, ...saveableMassTypes].map((type) => (
-            <Menu.Item
-              key={type}
-              onPress={() => {
-                setTypeToSave(type)
-                setMenuVisible(false)
-              }}
-              title={type.replace('HKQuantityTypeIdentifier', '')}
-            />
-          ))
-        }
+        {[...saveableCountTypes, ...saveableMassTypes].map((type) => (
+          <Menu.Item
+            key={type}
+            onPress={() => {
+              setTypeToSave(type)
+              setMenuVisible(false)
+            }}
+            title={type.replace('HKQuantityTypeIdentifier', '')}
+          />
+        ))}
       </Menu>
       <TextInput
         accessibilityLabel='Value'
@@ -408,58 +491,69 @@ const readPermissions: readonly HealthkitReadAuthorization[] = [
 ]
 
 const App = () => {
-  const [status, request] = useHealthkitAuthorization(readPermissions, [...saveableCountTypes, ...saveableMassTypes, ...saveableWorkoutStuff])
+  const [status, request] = useHealthkitAuthorization(readPermissions, [
+    ...saveableCountTypes,
+    ...saveableMassTypes,
+    ...saveableWorkoutStuff,
+  ])
 
-  return status !== HKAuthorizationRequestStatus.unnecessary
-    ? <View style={styles.buttonWrapper}><Button onPress={request}>Authorize</Button></View>
-    : (
-      <Provider>
-        <ScrollView style={styles.scrollView}>
-          <LatestWorkout icon='run' title='Latest workout' />
-          <List.AccordionGroup>
-            <List.Accordion title='Latest values' id='1'>
-              {
-                LATEST_QUANTITIES_TO_SHOW.map((e) => (
-                  <LatestListItem
-                    key={e.identifier}
-                    icon={e.icon}
-                    title={e.title}
-                    identifier={e.identifier}
-                  />
-                ))
-              }
-            </List.Accordion>
+  const [canAccessProtectedData, setAccessProtectedData] = useState<boolean>(false)
 
-            <List.Accordion title='Today stats' id='2'>
-              {
-                TODAY_STATS_TO_SHOW.map((e) => (
-                  <TodayListItem
-                    key={e.identifier}
-                    icon={e.icon}
-                    title={e.title}
-                    identifier={e.identifier}
-                    option={e.option}
-                    unit={e.unit}
-                  />
-                ))
-              }
-            </List.Accordion>
+  useEffect(() => {
+    Healthkit.canAccessProtectedData()
+      .then(setAccessProtectedData)
+      .catch(() => setAccessProtectedData(false))
+  }, [])
 
-            <List.Accordion title='Save Quantity' id='3'>
-              <SaveQuantity />
-            </List.Accordion>
+  return status !== HKAuthorizationRequestStatus.unnecessary ? (
+    <View style={styles.buttonWrapper}>
+      <Button onPress={request}>Authorize</Button>
+    </View>
+  ) : (
+    <Provider>
+      <ScrollView style={styles.scrollView}>
+        <LatestWorkout icon='run' title='Latest workout' />
+        <List.AccordionGroup>
+          <List.Accordion title='Latest values' id='1'>
+            {LATEST_QUANTITIES_TO_SHOW.map((e) => (
+              <LatestListItem
+                key={e.identifier}
+                icon={e.icon}
+                title={e.title}
+                identifier={e.identifier}
+              />
+            ))}
+          </List.Accordion>
 
-            <List.Accordion title='Delete Latest Quantity' id='4'>
-              <DeleteQuantity />
-            </List.Accordion>
+          <List.Accordion title='Today stats' id='2'>
+            {TODAY_STATS_TO_SHOW.map((e) => (
+              <TodayListItem
+                key={e.identifier}
+                icon={e.icon}
+                title={e.title}
+                identifier={e.identifier}
+                option={e.option}
+                unit={e.unit}
+              />
+            ))}
+          </List.Accordion>
 
-            <List.Accordion title='Save Workout' id='5'>
-              <SaveWorkout />
-            </List.Accordion>
-          </List.AccordionGroup>
-        </ScrollView>
-      </Provider>
-    )
+          <List.Accordion title='Save Quantity' id='3'>
+            <SaveQuantity />
+          </List.Accordion>
+
+          <List.Accordion title='Delete Latest Quantity' id='4'>
+            <DeleteQuantity />
+          </List.Accordion>
+
+          <List.Accordion title='Save Workout' id='5'>
+            <SaveWorkout />
+          </List.Accordion>
+        </List.AccordionGroup>
+        <Text>{`Can access protected data: ${canAccessProtectedData}`}</Text>
+      </ScrollView>
+    </Provider>
+  )
 }
 
 const styles = StyleSheet.create({

--- a/ios/ReactNativeHealthkit.m
+++ b/ios/ReactNativeHealthkit.m
@@ -158,4 +158,13 @@ RCT_EXTERN_METHOD(getWorkoutRoutes:(NSString)workoutUUID
                   reject:(RCTPromiseRejectBlock)reject
 )
 
+RCT_EXTERN_METHOD(getWorkoutRoutes:(NSString)workoutUUID
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(canAccessProtectedData:(RCTPromiseResolveBlock)resolve
+withRejecter:(RCTPromiseRejectBlock)reject)
+
+
 @end

--- a/src/index.ios.tsx
+++ b/src/index.ios.tsx
@@ -29,8 +29,10 @@ const Healthkit = {
   authorizationStatusFor: Native.authorizationStatusFor.bind(Native),
 
   isHealthDataAvailable: Native.isHealthDataAvailable.bind(Native),
+  canAccessProtectedData: Native.canAccessProtectedData.bind(Native),
 
-  disableAllBackgroundDelivery: Native.disableAllBackgroundDelivery.bind(Native),
+  disableAllBackgroundDelivery:
+    Native.disableAllBackgroundDelivery.bind(Native),
   disableBackgroundDelivery: Native.disableBackgroundDelivery.bind(Native),
   enableBackgroundDelivery: Native.enableBackgroundDelivery.bind(Native),
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,6 +67,7 @@ const Healthkit: typeof ReactNativeHealthkit = {
   useSubscribeToChanges: UnavailableFn([null, () => null]),
   useHealthkitAuthorization: UnavailableFn([null, async () => Promise.resolve(HKAuthorizationRequestStatus.unknown)] as const),
   useIsHealthDataAvailable: () => false,
+  canAccessProtectedData: async () => Promise.resolve(false),
 }
 
 export * from './types'

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -31,6 +31,7 @@ const mockModule: (NativeModule & typeof Native) = {
   saveWorkoutSample: jest.fn(),
   subscribeToObserverQuery: jest.fn(),
   unsubscribeQuery: jest.fn(),
+  canAccessProtectedData: jest.fn(),
 }
 
 NativeModules.ReactNativeHealthkit = mockModule

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -1,12 +1,6 @@
-import {
-  NativeEventEmitter,
-  NativeModules,
-} from 'react-native'
+import { NativeEventEmitter, NativeModules } from 'react-native'
 
-import type {
-  EmitterSubscription,
-  NativeModule,
-} from 'react-native'
+import type { EmitterSubscription, NativeModule } from 'react-native'
 
 export const HKWorkoutTypeIdentifier = 'HKWorkoutTypeIdentifier' as const
 export const HKAudiogramTypeIdentifier = 'HKAudiogramTypeIdentifier' as const
@@ -127,8 +121,8 @@ export enum HKQuantityTypeIdentifier {
   numberOfAlcoholicBeverages = 'HKQuantityTypeIdentifierNumberOfAlcoholicBeverages', // Scalar(Count),               Cumulative
 }
 
-export type TypeToUnitMapping = { readonly
-  [key in HKQuantityTypeIdentifier]: HKUnit;
+export type TypeToUnitMapping = {
+  readonly [key in HKQuantityTypeIdentifier]: HKUnit;
 };
 
 export enum HKCategoryValueLowCardioFitnessEvent {
@@ -211,23 +205,26 @@ export enum HKCategoryTypeIdentifier {
   vaginalDryness = 'HKCategoryTypeIdentifierVaginalDryness', // HKCategoryValueSeverity
   vomiting = 'HKCategoryTypeIdentifierVomiting', // HKCategoryValueSeverity
   wheezing = 'HKCategoryTypeIdentifierWheezing', // HKCategoryValueSeverity
-
 }
 
 export type HKSampleTypeIdentifier =
-HKCategoryTypeIdentifier
-| HKCorrelationTypeIdentifier
-| HKQuantityTypeIdentifier
-| typeof HKAudiogramTypeIdentifier
-| typeof HKDataTypeIdentifierHeartbeatSeries
-| typeof HKWorkoutRouteTypeIdentifier
-| typeof HKWorkoutTypeIdentifier
-| `${HKCategoryTypeIdentifier}`
-| `${HKCorrelationTypeIdentifier}`
-| `${HKQuantityTypeIdentifier}`
+  | HKCategoryTypeIdentifier
+  | HKCorrelationTypeIdentifier
+  | HKQuantityTypeIdentifier
+  | typeof HKAudiogramTypeIdentifier
+  | typeof HKDataTypeIdentifierHeartbeatSeries
+  | typeof HKWorkoutRouteTypeIdentifier
+  | typeof HKWorkoutTypeIdentifier
+  | `${HKCategoryTypeIdentifier}`
+  | `${HKCorrelationTypeIdentifier}`
+  | `${HKQuantityTypeIdentifier}`;
 
-export type HealthkitReadAuthorization = HKCharacteristicTypeIdentifier | HKSampleTypeIdentifier | `${HKCharacteristicTypeIdentifier}` | `${HKSampleTypeIdentifier}`
-export type HealthkitWriteAuthorization = HKSampleTypeIdentifier
+export type HealthkitReadAuthorization =
+  | HKCharacteristicTypeIdentifier
+  | HKSampleTypeIdentifier
+  | `${HKCharacteristicTypeIdentifier}`
+  | `${HKSampleTypeIdentifier}`;
+export type HealthkitWriteAuthorization = HKSampleTypeIdentifier;
 
 export enum HKCategoryValueAppleStandHour {
   stood = 0,
@@ -372,11 +369,17 @@ enum HKIndoorWorkout {
 export interface HKWorkoutMetadata
   extends HKGenericMetadata /* <TTemperatureUnit extends HKUnit> */ {
   readonly HKWeatherCondition?: HKWeatherCondition;
-  readonly HKWeatherHumidity?: HKQuantity<HKQuantityTypeIdentifier, HKUnits.Percent>;
+  readonly HKWeatherHumidity?: HKQuantity<
+  HKQuantityTypeIdentifier,
+  HKUnits.Percent
+  >;
   // HKWeatherTemperature: HKQuantity<TTemperatureUnit>
-  readonly HKAverageMETs?: HKQuantity<HKQuantityTypeIdentifier, HKUnit>,
-  readonly HKElevationAscended?: HKQuantity<HKQuantityTypeIdentifier, LengthUnit>,
-  readonly HKIndoorWorkout?: HKIndoorWorkout,
+  readonly HKAverageMETs?: HKQuantity<HKQuantityTypeIdentifier, HKUnit>;
+  readonly HKElevationAscended?: HKQuantity<
+  HKQuantityTypeIdentifier,
+  LengthUnit
+  >;
+  readonly HKIndoorWorkout?: HKIndoorWorkout;
 }
 
 export enum HKAuthorizationRequestStatus {
@@ -391,7 +394,10 @@ export enum HKAuthorizationStatus {
   sharingAuthorized = 2,
 }
 
-export type HKQuantity<TIdentifier extends HKQuantityTypeIdentifier = HKQuantityTypeIdentifier, TUnit extends UnitForIdentifier<TIdentifier> = UnitForIdentifier<TIdentifier>> = {
+export type HKQuantity<
+  TIdentifier extends HKQuantityTypeIdentifier = HKQuantityTypeIdentifier,
+  TUnit extends UnitForIdentifier<TIdentifier> = UnitForIdentifier<TIdentifier>
+> = {
   readonly unit: TUnit;
   readonly quantity: number;
 };
@@ -436,13 +442,19 @@ export enum HKStatisticsOptions {
   separateBySource = 'separateBySource',
 }
 
-export type QueryStatisticsResponseRaw<TIdentifier extends HKQuantityTypeIdentifier, TUnit extends UnitForIdentifier<TIdentifier>> = {
+export type QueryStatisticsResponseRaw<
+  TIdentifier extends HKQuantityTypeIdentifier,
+  TUnit extends UnitForIdentifier<TIdentifier>
+> = {
   readonly averageQuantity?: HKQuantity<TIdentifier, TUnit>;
   readonly maximumQuantity?: HKQuantity<TIdentifier, TUnit>;
   readonly minimumQuantity?: HKQuantity<TIdentifier, TUnit>;
   readonly sumQuantity?: HKQuantity<TIdentifier, TUnit>;
   readonly mostRecentQuantity?: HKQuantity<TIdentifier, TUnit>;
-  readonly mostRecentQuantityDateInterval?: { readonly from: string; readonly to: string };
+  readonly mostRecentQuantityDateInterval?: {
+    readonly from: string;
+    readonly to: string;
+  };
   readonly duration?: HKQuantity<HKQuantityTypeIdentifier, TimeUnit>;
 };
 
@@ -500,10 +512,15 @@ export enum HKCategoryValueNotApplicable {
 }
 
 export type HKCategoryValue =
-  HKCategoryValueAppetiteChanges | HKCategoryValueCervicalMucusQuality |
-  HKCategoryValueLowCardioFitnessEvent | HKCategoryValueMenstrualFlow |
-  HKCategoryValueOvulationTestResult | HKCategoryValuePresence |
-  HKCategoryValueSeverity | HKCategoryValueSleepAnalysis | number;
+  | HKCategoryValueAppetiteChanges
+  | HKCategoryValueCervicalMucusQuality
+  | HKCategoryValueLowCardioFitnessEvent
+  | HKCategoryValueMenstrualFlow
+  | HKCategoryValueOvulationTestResult
+  | HKCategoryValuePresence
+  | HKCategoryValueSeverity
+  | HKCategoryValueSleepAnalysis
+  | number;
 
 export enum HKInsulinDeliveryReason {
   basal = 1,
@@ -534,37 +551,102 @@ export type MetadataMapperForCorrelationIdentifier<
   }
   : HKGenericMetadata;
 
-export type UnitForIdentifier<T extends HKQuantityTypeIdentifier> = T extends HKQuantityTypeIdentifier.bloodGlucose ? BloodGlucoseUnit
-  : T extends HKQuantityTypeIdentifier.appleExerciseTime | HKQuantityTypeIdentifier.appleMoveTime | HKQuantityTypeIdentifier.appleStandTime ? TimeUnit
-    : T extends HKQuantityTypeIdentifier.activeEnergyBurned | HKQuantityTypeIdentifier.basalEnergyBurned | HKQuantityTypeIdentifier.dietaryEnergyConsumed ? EnergyUnit
-      : T extends HKQuantityTypeIdentifier.distanceCycling | HKQuantityTypeIdentifier.distanceDownhillSnowSports
-      | HKQuantityTypeIdentifier.distanceSwimming | HKQuantityTypeIdentifier.distanceWalkingRunning
-      | HKQuantityTypeIdentifier.distanceWheelchair | HKQuantityTypeIdentifier.sixMinuteWalkTestDistance
-      | HKQuantityTypeIdentifier.waistCircumference ? LengthUnit
-        : T extends HKQuantityTypeIdentifier.bodyFatPercentage | HKQuantityTypeIdentifier.oxygenSaturation | HKQuantityTypeIdentifier.walkingAsymmetryPercentage
-        | HKQuantityTypeIdentifier.walkingDoubleSupportPercentage ? HKUnits.Percent
-          : T extends HKQuantityTypeIdentifier.basalBodyTemperature | HKQuantityTypeIdentifier.basalBodyTemperature ? TemperatureUnit
-            : T extends HKQuantityTypeIdentifier.stairAscentSpeed | HKQuantityTypeIdentifier.stairDescentSpeed | HKQuantityTypeIdentifier.walkingSpeed
-            | HKQuantityTypeIdentifier.walkingSpeed ? SpeedUnit<LengthUnit, TimeUnit>
-              : T extends HKQuantityTypeIdentifier.flightsClimbed | HKQuantityTypeIdentifier.numberOfAlcoholicBeverages | HKQuantityTypeIdentifier.numberOfTimesFallen
-              | HKQuantityTypeIdentifier.pushCount | HKQuantityTypeIdentifier.stepCount | HKQuantityTypeIdentifier.swimmingStrokeCount ? HKUnits.Count
-                : T extends HKQuantityTypeIdentifier.dietaryBiotin | HKQuantityTypeIdentifier.dietaryCaffeine | HKQuantityTypeIdentifier.dietaryCalcium
-                | HKQuantityTypeIdentifier.dietaryCarbohydrates | HKQuantityTypeIdentifier.dietaryChloride | HKQuantityTypeIdentifier.dietaryCholesterol
-                | HKQuantityTypeIdentifier.dietaryChromium | HKQuantityTypeIdentifier.dietaryCopper | HKQuantityTypeIdentifier.dietaryFatMonounsaturated
-                | HKQuantityTypeIdentifier.dietaryFatPolyunsaturated | HKQuantityTypeIdentifier.dietaryFatSaturated | HKQuantityTypeIdentifier.dietaryFatTotal
-                | HKQuantityTypeIdentifier.dietaryFiber | HKQuantityTypeIdentifier.dietaryFolate | HKQuantityTypeIdentifier.dietaryIodine | HKQuantityTypeIdentifier.dietaryIodine
-                | HKQuantityTypeIdentifier.dietaryIron | HKQuantityTypeIdentifier.dietaryMagnesium | HKQuantityTypeIdentifier.dietaryManganese
-                | HKQuantityTypeIdentifier.dietaryMolybdenum | HKQuantityTypeIdentifier.dietaryNiacin | HKQuantityTypeIdentifier.dietaryPantothenicAcid
-                | HKQuantityTypeIdentifier.dietaryPhosphorus | HKQuantityTypeIdentifier.dietaryPotassium | HKQuantityTypeIdentifier.dietaryProtein
-                | HKQuantityTypeIdentifier.dietaryRiboflavin | HKQuantityTypeIdentifier.dietarySelenium | HKQuantityTypeIdentifier.dietarySodium
-                | HKQuantityTypeIdentifier.dietarySugar | HKQuantityTypeIdentifier.dietaryThiamin | HKQuantityTypeIdentifier.dietaryVitaminA
-                | HKQuantityTypeIdentifier.dietaryVitaminB6 | HKQuantityTypeIdentifier.dietaryVitaminB12 | HKQuantityTypeIdentifier.dietaryVitaminC
-                | HKQuantityTypeIdentifier.dietaryVitaminD | HKQuantityTypeIdentifier.dietaryVitaminE | HKQuantityTypeIdentifier.dietaryVitaminK
-                | HKQuantityTypeIdentifier.dietaryZinc ? MassUnit
-                  : T extends HKQuantityTypeIdentifier.dietaryWater ? VolumeUnit
-                    : T extends HKQuantityTypeIdentifier.insulinDelivery ? HKUnits.InternationalUnit | `${HKUnits.InternationalUnit}`
-                      : T extends HKQuantityTypeIdentifier.heartRate | HKQuantityTypeIdentifier.restingHeartRate | HKQuantityTypeIdentifier.walkingHeartRateAverage ? CountPerTime<TimeUnit>
-                        : HKUnit
+export type UnitForIdentifier<T extends HKQuantityTypeIdentifier> =
+  T extends HKQuantityTypeIdentifier.bloodGlucose
+    ? BloodGlucoseUnit
+    : T extends
+    | HKQuantityTypeIdentifier.appleExerciseTime
+    | HKQuantityTypeIdentifier.appleMoveTime
+    | HKQuantityTypeIdentifier.appleStandTime
+      ? TimeUnit
+      : T extends
+      | HKQuantityTypeIdentifier.activeEnergyBurned
+      | HKQuantityTypeIdentifier.basalEnergyBurned
+      | HKQuantityTypeIdentifier.dietaryEnergyConsumed
+        ? EnergyUnit
+        : T extends
+        | HKQuantityTypeIdentifier.distanceCycling
+        | HKQuantityTypeIdentifier.distanceDownhillSnowSports
+        | HKQuantityTypeIdentifier.distanceSwimming
+        | HKQuantityTypeIdentifier.distanceWalkingRunning
+        | HKQuantityTypeIdentifier.distanceWheelchair
+        | HKQuantityTypeIdentifier.sixMinuteWalkTestDistance
+        | HKQuantityTypeIdentifier.waistCircumference
+          ? LengthUnit
+          : T extends
+          | HKQuantityTypeIdentifier.bodyFatPercentage
+          | HKQuantityTypeIdentifier.oxygenSaturation
+          | HKQuantityTypeIdentifier.walkingAsymmetryPercentage
+          | HKQuantityTypeIdentifier.walkingDoubleSupportPercentage
+            ? HKUnits.Percent
+            : T extends
+            | HKQuantityTypeIdentifier.basalBodyTemperature
+            | HKQuantityTypeIdentifier.basalBodyTemperature
+              ? TemperatureUnit
+              : T extends
+              | HKQuantityTypeIdentifier.stairAscentSpeed
+              | HKQuantityTypeIdentifier.stairDescentSpeed
+              | HKQuantityTypeIdentifier.walkingSpeed
+              | HKQuantityTypeIdentifier.walkingSpeed
+                ? SpeedUnit<LengthUnit, TimeUnit>
+                : T extends
+                | HKQuantityTypeIdentifier.flightsClimbed
+                | HKQuantityTypeIdentifier.numberOfAlcoholicBeverages
+                | HKQuantityTypeIdentifier.numberOfTimesFallen
+                | HKQuantityTypeIdentifier.pushCount
+                | HKQuantityTypeIdentifier.stepCount
+                | HKQuantityTypeIdentifier.swimmingStrokeCount
+                  ? HKUnits.Count
+                  : T extends
+                  | HKQuantityTypeIdentifier.dietaryBiotin
+                  | HKQuantityTypeIdentifier.dietaryCaffeine
+                  | HKQuantityTypeIdentifier.dietaryCalcium
+                  | HKQuantityTypeIdentifier.dietaryCarbohydrates
+                  | HKQuantityTypeIdentifier.dietaryChloride
+                  | HKQuantityTypeIdentifier.dietaryCholesterol
+                  | HKQuantityTypeIdentifier.dietaryChromium
+                  | HKQuantityTypeIdentifier.dietaryCopper
+                  | HKQuantityTypeIdentifier.dietaryFatMonounsaturated
+                  | HKQuantityTypeIdentifier.dietaryFatPolyunsaturated
+                  | HKQuantityTypeIdentifier.dietaryFatSaturated
+                  | HKQuantityTypeIdentifier.dietaryFatTotal
+                  | HKQuantityTypeIdentifier.dietaryFiber
+                  | HKQuantityTypeIdentifier.dietaryFolate
+                  | HKQuantityTypeIdentifier.dietaryIodine
+                  | HKQuantityTypeIdentifier.dietaryIodine
+                  | HKQuantityTypeIdentifier.dietaryIron
+                  | HKQuantityTypeIdentifier.dietaryMagnesium
+                  | HKQuantityTypeIdentifier.dietaryManganese
+                  | HKQuantityTypeIdentifier.dietaryMolybdenum
+                  | HKQuantityTypeIdentifier.dietaryNiacin
+                  | HKQuantityTypeIdentifier.dietaryPantothenicAcid
+                  | HKQuantityTypeIdentifier.dietaryPhosphorus
+                  | HKQuantityTypeIdentifier.dietaryPotassium
+                  | HKQuantityTypeIdentifier.dietaryProtein
+                  | HKQuantityTypeIdentifier.dietaryRiboflavin
+                  | HKQuantityTypeIdentifier.dietarySelenium
+                  | HKQuantityTypeIdentifier.dietarySodium
+                  | HKQuantityTypeIdentifier.dietarySugar
+                  | HKQuantityTypeIdentifier.dietaryThiamin
+                  | HKQuantityTypeIdentifier.dietaryVitaminA
+                  | HKQuantityTypeIdentifier.dietaryVitaminB6
+                  | HKQuantityTypeIdentifier.dietaryVitaminB12
+                  | HKQuantityTypeIdentifier.dietaryVitaminC
+                  | HKQuantityTypeIdentifier.dietaryVitaminD
+                  | HKQuantityTypeIdentifier.dietaryVitaminE
+                  | HKQuantityTypeIdentifier.dietaryVitaminK
+                  | HKQuantityTypeIdentifier.dietaryZinc
+                    ? MassUnit
+                    : T extends HKQuantityTypeIdentifier.dietaryWater
+                      ? VolumeUnit
+                      : T extends HKQuantityTypeIdentifier.insulinDelivery
+                        ? HKUnits.InternationalUnit | `${HKUnits.InternationalUnit}`
+                        : T extends
+                        | HKQuantityTypeIdentifier.heartRate
+                        | HKQuantityTypeIdentifier.restingHeartRate
+                        | HKQuantityTypeIdentifier.walkingHeartRateAverage
+                          ? CountPerTime<TimeUnit>
+                          : HKUnit;
 
 export type HKCategoryValueForIdentifier<T extends HKCategoryTypeIdentifier> =
   T extends HKCategoryTypeIdentifier.cervicalMucusQuality
@@ -575,39 +657,70 @@ export type HKCategoryValueForIdentifier<T extends HKCategoryTypeIdentifier> =
         ? HKCategoryValueOvulationTestResult
         : T extends HKCategoryTypeIdentifier.sleepAnalysis
           ? HKCategoryValueSleepAnalysis
-          : T extends (HKCategoryTypeIdentifier.highHeartRateEvent | HKCategoryTypeIdentifier.intermenstrualBleeding
-          | HKCategoryTypeIdentifier.mindfulSession | HKCategoryTypeIdentifier.sexualActivity)
+          : T extends
+          | HKCategoryTypeIdentifier.highHeartRateEvent
+          | HKCategoryTypeIdentifier.intermenstrualBleeding
+          | HKCategoryTypeIdentifier.mindfulSession
+          | HKCategoryTypeIdentifier.sexualActivity
             ? HKCategoryValueNotApplicable
-            : T extends (HKCategoryTypeIdentifier.abdominalCramps
+            : T extends
+            | HKCategoryTypeIdentifier.abdominalCramps
             | HKCategoryTypeIdentifier.abdominalCramps
             | HKCategoryTypeIdentifier.acne
             | HKCategoryTypeIdentifier.bladderIncontinence
-            | HKCategoryTypeIdentifier.bloating| HKCategoryTypeIdentifier.breastPain
-            | HKCategoryTypeIdentifier.chestTightnessOrPain| HKCategoryTypeIdentifier.chills| HKCategoryTypeIdentifier.constipation
-            | HKCategoryTypeIdentifier.coughing| HKCategoryTypeIdentifier.diarrhea| HKCategoryTypeIdentifier.dizziness| HKCategoryTypeIdentifier.drySkin| HKCategoryTypeIdentifier.fainting
-            | HKCategoryTypeIdentifier.fatigue| HKCategoryTypeIdentifier.fever| HKCategoryTypeIdentifier.generalizedBodyAche| HKCategoryTypeIdentifier.hairLoss
-            | HKCategoryTypeIdentifier.headache| HKCategoryTypeIdentifier.heartburn
-            | HKCategoryTypeIdentifier.hotFlashes| HKCategoryTypeIdentifier.lossOfSmell| HKCategoryTypeIdentifier.lossOfTaste
-            | HKCategoryTypeIdentifier.lowerBackPain| HKCategoryTypeIdentifier.memoryLapse| HKCategoryTypeIdentifier.moodChanges
-            | HKCategoryTypeIdentifier.nausea| HKCategoryTypeIdentifier.nightSweats| HKCategoryTypeIdentifier.pelvicPain
-            | HKCategoryTypeIdentifier.rapidPoundingOrFlutteringHeartbeat| HKCategoryTypeIdentifier.runnyNose
-            | HKCategoryTypeIdentifier.shortnessOfBreath| HKCategoryTypeIdentifier.sinusCongestion| HKCategoryTypeIdentifier.skippedHeartbeat
-            | HKCategoryTypeIdentifier.soreThroat| HKCategoryTypeIdentifier.vaginalDryness
-            | HKCategoryTypeIdentifier.vomiting| HKCategoryTypeIdentifier.wheezing)
+            | HKCategoryTypeIdentifier.bloating
+            | HKCategoryTypeIdentifier.breastPain
+            | HKCategoryTypeIdentifier.chestTightnessOrPain
+            | HKCategoryTypeIdentifier.chills
+            | HKCategoryTypeIdentifier.constipation
+            | HKCategoryTypeIdentifier.coughing
+            | HKCategoryTypeIdentifier.diarrhea
+            | HKCategoryTypeIdentifier.dizziness
+            | HKCategoryTypeIdentifier.drySkin
+            | HKCategoryTypeIdentifier.fainting
+            | HKCategoryTypeIdentifier.fatigue
+            | HKCategoryTypeIdentifier.fever
+            | HKCategoryTypeIdentifier.generalizedBodyAche
+            | HKCategoryTypeIdentifier.hairLoss
+            | HKCategoryTypeIdentifier.headache
+            | HKCategoryTypeIdentifier.heartburn
+            | HKCategoryTypeIdentifier.hotFlashes
+            | HKCategoryTypeIdentifier.lossOfSmell
+            | HKCategoryTypeIdentifier.lossOfTaste
+            | HKCategoryTypeIdentifier.lowerBackPain
+            | HKCategoryTypeIdentifier.memoryLapse
+            | HKCategoryTypeIdentifier.moodChanges
+            | HKCategoryTypeIdentifier.nausea
+            | HKCategoryTypeIdentifier.nightSweats
+            | HKCategoryTypeIdentifier.pelvicPain
+            | HKCategoryTypeIdentifier.rapidPoundingOrFlutteringHeartbeat
+            | HKCategoryTypeIdentifier.runnyNose
+            | HKCategoryTypeIdentifier.shortnessOfBreath
+            | HKCategoryTypeIdentifier.sinusCongestion
+            | HKCategoryTypeIdentifier.skippedHeartbeat
+            | HKCategoryTypeIdentifier.soreThroat
+            | HKCategoryTypeIdentifier.vaginalDryness
+            | HKCategoryTypeIdentifier.vomiting
+            | HKCategoryTypeIdentifier.wheezing
               ? HKCategoryValueSeverity
-              : T extends (HKCategoryTypeIdentifier.appetiteChanges | HKCategoryTypeIdentifier.sleepChanges)
+              : T extends
+              | HKCategoryTypeIdentifier.appetiteChanges
+              | HKCategoryTypeIdentifier.sleepChanges
                 ? HKCategoryValuePresence
-                : T extends HKCategoryTypeIdentifier.lowCardioFitnessEvent ? HKCategoryValueLowCardioFitnessEvent :
-                  T extends HKCategoryTypeIdentifier.pregnancyTestResult ? HKCategoryValuePregnancyTestResult :
-                    T extends HKCategoryTypeIdentifier.pregnancyTestResult ? HKCategoryValuePregnancyTestResult :
-                      T extends HKCategoryTypeIdentifier.appleStandHour
+                : T extends HKCategoryTypeIdentifier.lowCardioFitnessEvent
+                  ? HKCategoryValueLowCardioFitnessEvent
+                  : T extends HKCategoryTypeIdentifier.pregnancyTestResult
+                    ? HKCategoryValuePregnancyTestResult
+                    : T extends HKCategoryTypeIdentifier.pregnancyTestResult
+                      ? HKCategoryValuePregnancyTestResult
+                      : T extends HKCategoryTypeIdentifier.appleStandHour
                         ? HKCategoryValueAppleStandHour
                         : number;
 
 enum HKCategoryValuePregnancyTestResult {
   positive = 2,
   negative = 1,
-  indeterminate = 3
+  indeterminate = 3,
 }
 /* needs further mapping
 
@@ -672,53 +785,63 @@ export enum HKUnitMetric {
 }
 
 export enum HKUnits {
-
   DecibelHearingLevel = 'dBHL',
   DecibelSoundPressureLevel = 'dBASPL',
 
   Percent = '%',
   Count = 'count',
   InternationalUnit = 'IU',
-
 }
 
-export type MeterUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}${HKUnitMetric.Meter}`;
-export type LiterUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}${HKUnitMetric.Liter}`;
-export type GramUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}${HKUnitMetric.Gram}`;
-export type PascalUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}${HKUnitMetric.Pascal}`;
-export type SecondUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}${HKUnitMetric.Second}`;
-export type JouleUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}${HKUnitMetric.Joule}`;
-export type HertzUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}${HKUnitMetric.Hertz}`;
-export type VoltUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}${HKUnitMetric.Volt}`;
-export type SiemenUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}${HKUnitMetric.Siemen}`;
+export type MeterUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =
+  `${Prefix}${HKUnitMetric.Meter}`;
+export type LiterUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =
+  `${Prefix}${HKUnitMetric.Liter}`;
+export type GramUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =
+  `${Prefix}${HKUnitMetric.Gram}`;
+export type PascalUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =
+  `${Prefix}${HKUnitMetric.Pascal}`;
+export type SecondUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =
+  `${Prefix}${HKUnitMetric.Second}`;
+export type JouleUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =
+  `${Prefix}${HKUnitMetric.Joule}`;
+export type HertzUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =
+  `${Prefix}${HKUnitMetric.Hertz}`;
+export type VoltUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =
+  `${Prefix}${HKUnitMetric.Volt}`;
+export type SiemenUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =
+  `${Prefix}${HKUnitMetric.Siemen}`;
 
 // not 100% sure about these
-export type MoleUnit<MolarMass extends number> =`mol<${MolarMass}>`;
-export type MoleUnitWith<MolarMass extends number, Prefix extends HKMetricPrefix = HKMetricPrefix.None> =`${Prefix}mol<${MolarMass}>`;
+export type MoleUnit<MolarMass extends number> = `mol<${MolarMass}>`;
+export type MoleUnitWith<
+  MolarMass extends number,
+  Prefix extends HKMetricPrefix = HKMetricPrefix.None
+> = `${Prefix}mol<${MolarMass}>`;
 
-export type FrequencyUnit = HertzUnit<HKMetricPrefix>
+export type FrequencyUnit = HertzUnit<HKMetricPrefix>;
 
 /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'cm', 'km'
-  */
+ * More SI prefixes also available as literals, just type the string
+ * @example 'cm', 'km'
+ */
 export enum UnitOfLength {
   Feet = 'ft',
   /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'cm', 'km'
-  */
+   * More SI prefixes also available as literals, just type the string
+   * @example 'cm', 'km'
+   */
   Meter = 'm',
   Inches = 'in',
   Yards = 'yd',
   Miles = 'mi',
 }
-export type LengthUnit = MeterUnit<HKMetricPrefix> | UnitOfLength
+export type LengthUnit = MeterUnit<HKMetricPrefix> | UnitOfLength;
 
 /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'ml', 'cl'
-  */
+ * More SI prefixes also available as literals, just type the string
+ * @example 'ml', 'cl'
+ */
 export enum UnitOfVolume {
   ImperialCup = 'cup_imp',
   ImperialFluidOunces = 'fl_oz_imp',
@@ -727,37 +850,37 @@ export enum UnitOfVolume {
   USFluidOunces = 'fl_oz_us',
   USPint = 'pt_us',
   /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'ml', 'cl'
-  */
+   * More SI prefixes also available as literals, just type the string
+   * @example 'ml', 'cl'
+   */
   Liter = 'l',
 }
 export type VolumeUnit = LiterUnit<HKMetricPrefix> | UnitOfVolume;
 
 /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'mg', 'kg'
-  */
+ * More SI prefixes also available as literals, just type the string
+ * @example 'mg', 'kg'
+ */
 export enum UnitOfMass {
   Ounces = 'oz',
   Stones = 'st',
   Pounds = 'lb',
   /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'mg', 'kg'
-  */
-  Gram = 'g'
+   * More SI prefixes also available as literals, just type the string
+   * @example 'mg', 'kg'
+   */
+  Gram = 'g',
 }
 /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'mg', 'kg'
-  */
-export type MassUnit = GramUnit<HKMetricPrefix> | UnitOfMass
+ * More SI prefixes also available as literals, just type the string
+ * @example 'mg', 'kg'
+ */
+export type MassUnit = GramUnit<HKMetricPrefix> | UnitOfMass;
 
 /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'kPa', 'hPa'
-  */
+ * More SI prefixes also available as literals, just type the string
+ * @example 'kPa', 'hPa'
+ */
 export enum UnitOfPressure {
   Atmospheres = 'atm',
   CentimetersOfWater = 'cmAq',
@@ -765,37 +888,37 @@ export enum UnitOfPressure {
   InchesOfMercury = 'inHg',
   DecibelAWeightedSoundPressureLevel = 'dBASPL',
   /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'kPa', 'hPa'
-  */
+   * More SI prefixes also available as literals, just type the string
+   * @example 'kPa', 'hPa'
+   */
   Pascals = 'Pa',
 }
 
 /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'kPa', 'hPa'
-  */
+ * More SI prefixes also available as literals, just type the string
+ * @example 'kPa', 'hPa'
+ */
 export type PressureUnit = PascalUnit<HKMetricPrefix> | UnitOfPressure;
 
 /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'ms'
-  */
+ * More SI prefixes also available as literals, just type the string
+ * @example 'ms'
+ */
 export enum UnitOfTime {
   Days = 'd',
   Minutes = 'min',
   Hours = 'hr',
   /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'ms'
-  */
+   * More SI prefixes also available as literals, just type the string
+   * @example 'ms'
+   */
   Seconds = 's',
 }
 /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'ms'
-  */
-export type TimeUnit = SecondUnit<HKMetricPrefix> | UnitOfTime
+ * More SI prefixes also available as literals, just type the string
+ * @example 'ms'
+ */
+export type TimeUnit = SecondUnit<HKMetricPrefix> | UnitOfTime;
 export enum TemperatureUnit {
   DegreesCelsius = 'degC',
   DegreesFahrenheit = 'degF',
@@ -803,33 +926,54 @@ export enum TemperatureUnit {
 }
 
 /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'kJ'
-  */
+ * More SI prefixes also available as literals, just type the string
+ * @example 'kJ'
+ */
 export enum UnitOfEnergy {
   Kilocalories = 'kcal',
   LargeCalories = 'Cal',
   SmallCalories = 'cal',
   /**
-  * More SI prefixes also available as literals, just type the string
-  * @example 'kJ'
-  */
+   * More SI prefixes also available as literals, just type the string
+   * @example 'kJ'
+   */
   Joules = 'J',
 }
-export type EnergyUnit = JouleUnit<HKMetricPrefix> | UnitOfEnergy
+export type EnergyUnit = JouleUnit<HKMetricPrefix> | UnitOfEnergy;
 export enum BloodGlucoseUnit {
   GlucoseMmolPerL = 'mmol<180.15588000005408>/l',
   GlucoseMgPerDl = 'mg/dL',
 }
 
-export type SpeedUnit<TLength extends LengthUnit, TTime extends TimeUnit> =`${TLength}/${TTime}`;
-export type CountPerTime<TTime extends TimeUnit> =`count/${TTime}`;
+export type SpeedUnit<
+  TLength extends LengthUnit,
+  TTime extends TimeUnit
+> = `${TLength}/${TTime}`;
+export type CountPerTime<TTime extends TimeUnit> = `count/${TTime}`;
 
-export type HKUnit = BloodGlucoseUnit | CountPerTime<TimeUnit> | EnergyUnit
-| FrequencyUnit | HKUnits | LengthUnit | MassUnit | PressureUnit | SpeedUnit<LengthUnit, TimeUnit>
-| TemperatureUnit | TimeUnit | VolumeUnit
-| `${BloodGlucoseUnit}` | `${EnergyUnit}` | `${FrequencyUnit}` | `${HKUnits}` | `${LengthUnit}`
-| `${MassUnit}` | `${PressureUnit}` | `${TemperatureUnit}` | `${TimeUnit}` | `${VolumeUnit}`;
+export type HKUnit =
+  | BloodGlucoseUnit
+  | CountPerTime<TimeUnit>
+  | EnergyUnit
+  | FrequencyUnit
+  | HKUnits
+  | LengthUnit
+  | MassUnit
+  | PressureUnit
+  | SpeedUnit<LengthUnit, TimeUnit>
+  | TemperatureUnit
+  | TimeUnit
+  | VolumeUnit
+  | `${BloodGlucoseUnit}`
+  | `${EnergyUnit}`
+  | `${FrequencyUnit}`
+  | `${HKUnits}`
+  | `${LengthUnit}`
+  | `${MassUnit}`
+  | `${PressureUnit}`
+  | `${TemperatureUnit}`
+  | `${TimeUnit}`
+  | `${VolumeUnit}`;
 
 export type HKDevice = {
   readonly name: string; // ex: "Apple Watch"
@@ -855,7 +999,7 @@ export type HKSourceRevision = {
 
 export type HKQuantitySampleRaw<
   TQuantityIdentifier extends HKQuantityTypeIdentifier = HKQuantityTypeIdentifier,
-  TUnit extends UnitForIdentifier<TQuantityIdentifier> = UnitForIdentifier<TQuantityIdentifier>,
+  TUnit extends UnitForIdentifier<TQuantityIdentifier> = UnitForIdentifier<TQuantityIdentifier>
 > = {
   readonly uuid: string;
   readonly device?: HKDevice;
@@ -870,28 +1014,37 @@ export type HKQuantitySampleRaw<
 
 export type HKQuantitySampleRawForSaving<
   TQuantityIdentifier extends HKQuantityTypeIdentifier = HKQuantityTypeIdentifier,
-  TUnit extends UnitForIdentifier<TQuantityIdentifier> = UnitForIdentifier<TQuantityIdentifier>,
+  TUnit extends UnitForIdentifier<TQuantityIdentifier> = UnitForIdentifier<TQuantityIdentifier>
 > = Omit<
 HKQuantitySampleRaw<TQuantityIdentifier, TUnit>,
 'device' | 'endDate' | 'startDate' | 'uuid'
->
+>;
 
 export type HKCategorySampleRawForSaving<
-  TCategory extends HKCategoryTypeIdentifier = HKCategoryTypeIdentifier,
+  TCategory extends HKCategoryTypeIdentifier = HKCategoryTypeIdentifier
 > = Omit<
 HKCategorySampleRaw<TCategory>,
 'device' | 'endDate' | 'startDate' | 'uuid'
->
+>;
 
-export type HKWorkoutRaw<TEnergy extends EnergyUnit, TDistance extends LengthUnit> = {
+export type HKWorkoutRaw<
+  TEnergy extends EnergyUnit,
+  TDistance extends LengthUnit
+> = {
   readonly uuid: string;
   readonly device?: HKDevice;
   readonly workoutActivityType: HKWorkoutActivityType;
   readonly duration: number;
   readonly totalDistance?: HKQuantity<HKQuantityTypeIdentifier, TDistance>;
   readonly totalEnergyBurned?: HKQuantity<HKQuantityTypeIdentifier, TEnergy>;
-  readonly totalSwimmingStrokeCount?: HKQuantity<HKQuantityTypeIdentifier, HKUnits.Count>;
-  readonly totalFlightsClimbed?: HKQuantity<HKQuantityTypeIdentifier, HKUnits.Count>;
+  readonly totalSwimmingStrokeCount?: HKQuantity<
+  HKQuantityTypeIdentifier,
+  HKUnits.Count
+  >;
+  readonly totalFlightsClimbed?: HKQuantity<
+  HKQuantityTypeIdentifier,
+  HKUnits.Count
+  >;
   readonly startDate: string;
   readonly endDate: string;
   readonly metadata?: HKWorkoutMetadata;
@@ -909,11 +1062,17 @@ export enum HKCharacteristicTypeIdentifier {
 }
 
 export type WritePermissions = {
-  readonly [key in HKCategoryTypeIdentifier | HKCharacteristicTypeIdentifier | HKQuantityTypeIdentifier]: boolean;
+  readonly [key in
+  | HKCategoryTypeIdentifier
+  | HKCharacteristicTypeIdentifier
+  | HKQuantityTypeIdentifier]: boolean;
 };
 
 export type ReadPermissions = {
-  readonly [key in HKCategoryTypeIdentifier | HKCharacteristicTypeIdentifier | HKQuantityTypeIdentifier]: boolean;
+  readonly [key in
+  | HKCategoryTypeIdentifier
+  | HKCharacteristicTypeIdentifier
+  | HKQuantityTypeIdentifier]: boolean;
 };
 
 export type HKCategorySampleRaw<
@@ -956,6 +1115,7 @@ export type WorkoutLocation = {
   readonly horizontalAccuracy: number;
   readonly speedAccuracy: number;
   readonly verticalAccuracy: number;
+  readonly distance: number | null;
 };
 
 export type WorkoutRoute = {
@@ -966,6 +1126,7 @@ export type WorkoutRoute = {
 
 type ReactNativeHealthkitTypeNative = {
   isHealthDataAvailable(): Promise<boolean>;
+  canAccessProtectedData(): Promise<boolean>;
   getBloodType(): Promise<HKBloodType>;
   getDateOfBirth(): Promise<string>;
   getBiologicalSex(): Promise<HKBiologicalSex>;
@@ -977,13 +1138,16 @@ type ReactNativeHealthkitTypeNative = {
     updateFrequency: HKUpdateFrequency
   ) => Promise<boolean>;
   readonly disableBackgroundDelivery: (
-    typeIdentifier: HKSampleTypeIdentifier,
+    typeIdentifier: HKSampleTypeIdentifier
   ) => Promise<boolean>;
   readonly disableAllBackgroundDelivery: () => Promise<boolean>;
 
   readonly saveCorrelationSample: <
     TIdentifier extends HKCorrelationTypeIdentifier,
-    TSamples extends readonly (HKCategorySampleRawForSaving | HKQuantitySampleRawForSaving)[]
+    TSamples extends readonly (
+      | HKCategorySampleRawForSaving
+      | HKQuantitySampleRawForSaving
+    )[]
   >(
     typeIdentifier: TIdentifier,
     samples: TSamples,
@@ -1000,7 +1164,9 @@ type ReactNativeHealthkitTypeNative = {
     metadata: HKWorkoutMetadata
   ) => Promise<boolean>;
 
-  readonly queryCorrelationSamples: <TIdentifier extends HKCorrelationTypeIdentifier>(
+  readonly queryCorrelationSamples: <
+    TIdentifier extends HKCorrelationTypeIdentifier
+  >(
     typeIdentifier: TIdentifier,
     from: string,
     to: string
@@ -1010,9 +1176,7 @@ type ReactNativeHealthkitTypeNative = {
     identifier: HKSampleTypeIdentifier
   ): Promise<QueryId>;
   unsubscribeQuery(queryId: QueryId): Promise<boolean>;
-  authorizationStatusFor(
-    type: HealthkitReadAuthorization
-  ): Promise<boolean>;
+  authorizationStatusFor(type: HealthkitReadAuthorization): Promise<boolean>;
   getRequestStatusForAuthorization(
     write: WritePermissions,
     read: ReadPermissions
@@ -1024,7 +1188,7 @@ type ReactNativeHealthkitTypeNative = {
   readonly saveQuantitySample: <
     TType extends HKQuantityTypeIdentifier,
     TUnit extends UnitForIdentifier<TType> = UnitForIdentifier<TType>
-  > (
+  >(
     identifier: TType,
     unit: TUnit,
     value: number,
@@ -1036,7 +1200,10 @@ type ReactNativeHealthkitTypeNative = {
     typeIdentifier: TIdentifier,
     uuid: string
   ) => Promise<boolean>;
-  readonly queryWorkoutSamples: <TEnergy extends EnergyUnit, TDistance extends LengthUnit>(
+  readonly queryWorkoutSamples: <
+    TEnergy extends EnergyUnit,
+    TDistance extends LengthUnit
+  >(
     energyUnit: TEnergy,
     distanceUnit: TDistance,
     from: string,
@@ -1053,7 +1220,7 @@ type ReactNativeHealthkitTypeNative = {
   ) => Promise<readonly HKCategorySampleRaw<T>[]>;
   readonly queryQuantitySamples: <
     TIdentifier extends HKQuantityTypeIdentifier,
-    TUnit extends UnitForIdentifier<TIdentifier>,
+    TUnit extends UnitForIdentifier<TIdentifier>
   >(
     identifier: TIdentifier,
     unit: TUnit,
@@ -1082,7 +1249,9 @@ type ReactNativeHealthkitTypeNative = {
   readonly getPreferredUnits: (
     identifiers: readonly HKQuantityTypeIdentifier[]
   ) => Promise<TypeToUnitMapping>;
-  readonly getWorkoutRoutes: (workoutUUID: string) => Promise<readonly WorkoutRoute[]>;
+  readonly getWorkoutRoutes: (
+    workoutUUID: string
+  ) => Promise<readonly WorkoutRoute[]>;
 };
 
 const Native = NativeModules.ReactNativeHealthkit as ReactNativeHealthkitTypeNative

--- a/src/utils/subscribeToChanges.ts
+++ b/src/utils/subscribeToChanges.ts
@@ -1,31 +1,31 @@
-import Native, { EventEmitter } from "../native-types";
+import Native, { EventEmitter } from '../native-types'
 
-import type { HKSampleTypeIdentifier } from "..";
+import type { HKSampleTypeIdentifier } from '..'
 
 const subscribeToChanges = async (
   identifier: HKSampleTypeIdentifier,
-  callback: () => void
+  callback: () => void,
 ) => {
   const subscription = EventEmitter.addListener(
-    "onChange",
+    'onChange',
     ({ typeIdentifier }) => {
       if (typeIdentifier === identifier) {
-        callback();
+        callback()
       }
-    }
-  );
+    },
+  )
 
   const queryId = await Native.subscribeToObserverQuery(identifier).catch(
     async (error) => {
-      subscription.remove();
-      return Promise.reject(error);
-    }
-  );
+      subscription.remove()
+      return Promise.reject(error)
+    },
+  )
 
   return async () => {
-    subscription.remove();
-    return Native.unsubscribeQuery(queryId);
-  };
-};
+    subscription.remove()
+    return Native.unsubscribeQuery(queryId)
+  }
+}
 
-export default subscribeToChanges;
+export default subscribeToChanges

--- a/src/utils/subscribeToChanges.ts
+++ b/src/utils/subscribeToChanges.ts
@@ -1,32 +1,31 @@
-import { EventEmitter } from '..'
-import Native from '../native-types'
+import Native, { EventEmitter } from "../native-types";
 
-import type { HKSampleTypeIdentifier } from '..'
+import type { HKSampleTypeIdentifier } from "..";
 
 const subscribeToChanges = async (
   identifier: HKSampleTypeIdentifier,
-  callback: () => void,
+  callback: () => void
 ) => {
   const subscription = EventEmitter.addListener(
-    'onChange',
+    "onChange",
     ({ typeIdentifier }) => {
       if (typeIdentifier === identifier) {
-        callback()
+        callback();
       }
-    },
-  )
+    }
+  );
 
   const queryId = await Native.subscribeToObserverQuery(identifier).catch(
     async (error) => {
-      subscription.remove()
-      return Promise.reject(error)
-    },
-  )
+      subscription.remove();
+      return Promise.reject(error);
+    }
+  );
 
   return async () => {
-    subscription.remove()
-    return Native.unsubscribeQuery(queryId)
-  }
-}
+    subscription.remove();
+    return Native.unsubscribeQuery(queryId);
+  };
+};
 
-export default subscribeToChanges
+export default subscribeToChanges;


### PR DESCRIPTION
Hi,
Here is a PR:
 - Adding `canAccessProtectedData` to check if protected data can be accessed (fixes https://github.com/Kingstinct/react-native-healthkit/issues/35 )
 - Fixing `EventEmitter` causing `addListener` to be called on undefined object
 - Adding `distance` to location data for a route