### PR TITLE
Pr/including deletesamples method

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -74,7 +74,7 @@ PODS:
   - fmt (6.2.1)
   - glog (0.3.5)
   - hermes-engine (0.11.0)
-  - kingstinct-react-native-healthkit (5.1.1):
+  - kingstinct-react-native-healthkit (5.2.1):
     - React
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
@@ -554,7 +554,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
   hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
-  kingstinct-react-native-healthkit: caaf2433704c7ec60583e5055fddf810947f31f5
+  kingstinct-react-native-healthkit: 2fa5f31ee900828ca414772b3d64628b415864be
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -398,7 +398,8 @@ const DeleteSample = () => {
   const deleteFn = useCallback(() => {
     if (latestValue) {
       void deleteSamples({ identifier: typeToDelete, startDate: new Date(new Date(latestValue.startDate).getTime() - 1000), endDate: new Date(new Date(latestValue.endDate).getTime() + 1000) })
-  }}, [latestValue, typeToDelete])
+    }
+  }, [latestValue, typeToDelete])
 
   return (
     <>
@@ -516,7 +517,7 @@ const readPermissions: readonly HealthkitReadAuthorization[] = [
 
 const App = () => {
   const [status, request] = useHealthkitAuthorization(readPermissions, [
-      HKQuantityTypeIdentifier.bodyMass,
+    HKQuantityTypeIdentifier.bodyMass,
     ...saveableCountTypes,
     ...saveableMassTypes,
     ...saveableWorkoutStuff,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,6 +10,7 @@ import useMostRecentQuantitySample from '@kingstinct/react-native-healthkit/hook
 import useMostRecentWorkout from '@kingstinct/react-native-healthkit/hooks/useMostRecentWorkout'
 import useStatisticsForQuantity from '@kingstinct/react-native-healthkit/hooks/useStatisticsForQuantity'
 import deleteQuantitySample from '@kingstinct/react-native-healthkit/utils/deleteQuantitySample'
+import deleteSamples from '@kingstinct/react-native-healthkit/utils/deleteSamples'
 import saveQuantitySample from '@kingstinct/react-native-healthkit/utils/saveQuantitySample'
 import saveWorkoutSample from '@kingstinct/react-native-healthkit/utils/saveWorkoutSample'
 import dayjs from 'dayjs'
@@ -390,6 +391,28 @@ const DeleteQuantity = () => {
   )
 }
 
+const DeleteSample = () => {
+  const typeToDelete = HKQuantityTypeIdentifier.bodyMass
+  const latestValue = useMostRecentQuantitySample(typeToDelete)
+
+  const deleteFn = useCallback(() => {
+    if (latestValue) {
+      void deleteSamples({ identifier: typeToDelete, startDate: new Date(new Date(latestValue.startDate).getTime() - 1000), endDate: new Date(new Date(latestValue.endDate).getTime() + 1000) })
+  }}, [latestValue, typeToDelete])
+
+  return (
+    <>
+      <LatestListItem
+        key={typeToDelete}
+        icon='clock'
+        title='Latest value'
+        identifier={typeToDelete}
+      />
+      <Button onPress={deleteFn}>Delete Last Value</Button>
+    </>
+  )
+}
+
 const SaveQuantity = () => {
   const [typeToSave, setTypeToSave] = useState<HKQuantityTypeIdentifier>(
     HKQuantityTypeIdentifier.stepCount,
@@ -397,7 +420,7 @@ const SaveQuantity = () => {
   const [menuVisible, setMenuVisible] = useState<boolean>(false)
   const [saveValueStr, setSaveValueStr] = useState<string>('0')
 
-  const unit = saveableMassTypes.includes(typeToSave) ? 'g' : 'count'
+  const unit = saveableMassTypes.includes(typeToSave) || typeToSave === HKQuantityTypeIdentifier.bodyMass ? 'g' : 'count'
 
   const save = useCallback(() => {
     const val = parseFloat(saveValueStr)
@@ -424,7 +447,7 @@ const SaveQuantity = () => {
           </Button>
         )}
       >
-        {[...saveableCountTypes, ...saveableMassTypes].map((type) => (
+        {[...saveableCountTypes, ...saveableMassTypes, HKQuantityTypeIdentifier.bodyMass].map((type) => (
           <Menu.Item
             key={type}
             onPress={() => {
@@ -484,6 +507,7 @@ const readPermissions: readonly HealthkitReadAuthorization[] = [
   HKQuantityTypeIdentifier.heartRate,
   HKQuantityTypeIdentifier.swimmingStrokeCount,
   HKQuantityTypeIdentifier.bodyFatPercentage,
+  HKQuantityTypeIdentifier.bodyMass,
   ...LATEST_QUANTITIES_TO_SHOW.map((entry) => entry.identifier),
   ...TODAY_STATS_TO_SHOW.map((entry) => entry.identifier),
   ...saveableMassTypes,
@@ -492,6 +516,7 @@ const readPermissions: readonly HealthkitReadAuthorization[] = [
 
 const App = () => {
   const [status, request] = useHealthkitAuthorization(readPermissions, [
+      HKQuantityTypeIdentifier.bodyMass,
     ...saveableCountTypes,
     ...saveableMassTypes,
     ...saveableWorkoutStuff,
@@ -548,6 +573,10 @@ const App = () => {
 
           <List.Accordion title='Save Workout' id='5'>
             <SaveWorkout />
+          </List.Accordion>
+
+          <List.Accordion title='Delete Latest body mass Value' id='6'>
+            <DeleteSample />
           </List.Accordion>
         </List.AccordionGroup>
         <Text>{`Can access protected data: ${canAccessProtectedData}`}</Text>

--- a/ios/ReactNativeHealthkit.m
+++ b/ios/ReactNativeHealthkit.m
@@ -68,6 +68,13 @@ RCT_EXTERN_METHOD(deleteQuantitySample:(NSString)typeIdentifier
                   reject:(RCTPromiseRejectBlock)reject
 )
 
+RCT_EXTERN_METHOD(deleteSamples:(NSString)typeIdentifier
+                  start:(NSDate)start
+                  end:(NSDate)end
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject
+)
+
 RCT_EXTERN_METHOD(subscribeToObserverQuery:(NSString)typeIdentifier
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -409,6 +409,28 @@ class ReactNativeHealthkit: RCTEventEmitter {
         }
     }
 
+    @objc(deleteSamples:start:end:resolve:reject:)
+    func deleteSamples(typeIdentifier: String, start: Date, end: Date, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock){
+        guard let store = _store else {
+            return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
+        }
+
+        let identifier = HKQuantityTypeIdentifier.init(rawValue: typeIdentifier);
+
+        guard let sampleType = HKObjectType.quantityType(forIdentifier: identifier) else {
+            return reject(TYPE_IDENTIFIER_ERROR, typeIdentifier, nil);
+        }
+
+        let samplePredicate = HKQuery.predicateForSamples(withStart: start, end: end, options: HKQueryOptions.strictStartDate);
+
+        store.deleteObjects(of: sampleType, predicate: samplePredicate) { (success: Bool, deletedObjectCount: Int, error: Error?) in
+            guard let err = error else {
+                return resolve(success);
+            }
+            reject(GENERIC_ERROR, err.localizedDescription, error);
+        }
+    }
+
     @objc(saveCorrelationSample:samples:start:end:metadata:resolve:reject:)
     func saveCorrelationSample(typeIdentifier: String, samples: Array<Dictionary<String, Any>>, start: Date, end: Date, metadata: Dictionary<String, Any>, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock){
         guard let store = _store else {

--- a/src/index.ios.tsx
+++ b/src/index.ios.tsx
@@ -6,6 +6,7 @@ import useMostRecentWorkout from './hooks/useMostRecentWorkout'
 import useSubscribeToChanges from './hooks/useSubscribeToChanges'
 import Native from './native-types'
 import deleteQuantitySample from './utils/deleteQuantitySample'
+import deleteSamples from './utils/deleteSamples'
 import getDateOfBirth from './utils/getDateOfBirth'
 import getMostRecentCategorySample from './utils/getMostRecentCategorySample'
 import getMostRecentQuantitySample from './utils/getMostRecentQuantitySample'
@@ -65,6 +66,7 @@ const Healthkit = {
 
   // delete methods
   deleteQuantitySample,
+  deleteSamples,
 
   // save methods
   saveCategorySample,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,6 +56,7 @@ const Healthkit: typeof ReactNativeHealthkit = {
   queryWorkouts: UnavailableFn(Promise.resolve([])),
   requestAuthorization: UnavailableFn(Promise.resolve(false)),
   deleteQuantitySample: UnavailableFn(Promise.resolve(false)),
+  deleteSamples: UnavailableFn(Promise.resolve(false)),
   saveCategorySample: UnavailableFn(Promise.resolve(false)),
   saveCorrelationSample: UnavailableFn(Promise.resolve(false)),
   saveQuantitySample: UnavailableFn(Promise.resolve(false)),

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -10,6 +10,7 @@ const mockModule: (NativeModule & typeof Native) = {
   requestAuthorization: jest.fn(),
   saveQuantitySample: jest.fn(),
   deleteQuantitySample: jest.fn(),
+  deleteSamples: jest.fn(),
   disableAllBackgroundDelivery: jest.fn(),
   disableBackgroundDelivery: jest.fn(),
   enableBackgroundDelivery: jest.fn(),

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -1212,6 +1212,11 @@ type ReactNativeHealthkitTypeNative = {
     typeIdentifier: TIdentifier,
     uuid: string
   ) => Promise<boolean>;
+  readonly deleteSamples: <TIdentifier extends HKQuantityTypeIdentifier>(
+    identifier: TIdentifier,
+    start: string,
+    end: string,
+  ) => Promise<boolean>;
   readonly queryWorkoutSamples: <
     TEnergy extends EnergyUnit,
     TDistance extends LengthUnit

--- a/src/utils/deleteSamples.ts
+++ b/src/utils/deleteSamples.ts
@@ -1,0 +1,23 @@
+import Native from '../native-types'
+
+import type { HKQuantityTypeIdentifier } from '../native-types'
+
+export type DeleteSamplesFn = <
+  TIdentifier extends HKQuantityTypeIdentifier
+>(
+  sample: {
+    readonly identifier: TIdentifier,
+    readonly startDate?: Date;
+    readonly endDate?: Date;
+  }
+) => Promise<boolean>
+
+const deleteSamples: DeleteSamplesFn = async (sample) => {
+  const start = sample.startDate || new Date()
+  const end = sample.endDate || new Date()
+  const { identifier } = sample
+
+  return Native.deleteSamples(identifier, start.toISOString(), end.toISOString())
+}
+
+export default deleteSamples


### PR DESCRIPTION
Hi, please take a look at the PR. It refers to an [enhancement](https://github.com/Kingstinct/react-native-healthkit/issues/24) due to the addition of a new method for deleting objects.
The deleteSamples method is implemented based on deleteobjects from [apple documentation](https://developer.apple.com/documentation/healthkit/hkhealthstore/1614162-deleteobjects). 
Please take a look and if possible, check whether everything is implemented correctly. I will be waiting for your feedback and merge.
And thank you once again for this wonderful library