### PR TITLE
feat(hk sources): add function for fetching hk sources

### DIFF
--- a/ios/ReactNativeHealthkit.m
+++ b/ios/ReactNativeHealthkit.m
@@ -143,6 +143,11 @@ RCT_EXTERN_METHOD(queryQuantitySamples:(NSString)typeIdentifier
                   reject:(RCTPromiseRejectBlock)reject
 )
 
+RCT_EXTERN_METHOD(querySources:(NSString)typeIdentifier
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject
+)
+
 RCT_EXTERN_METHOD(unsubscribeQuery:(NSString)queryId
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject

--- a/src/hooks/useSources.ts
+++ b/src/hooks/useSources.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import querySources from '../utils/querySources'
+
+import type {
+  HKCategoryTypeIdentifier,
+  HKQuantityTypeIdentifier,
+  HKSource,
+} from '../native-types'
+
+function useSources<
+  TIdentifier extends HKCategoryTypeIdentifier | HKQuantityTypeIdentifier
+>(identifier: TIdentifier) {
+  const [result, setResult] = useState<readonly HKSource[] | null>(null)
+
+  const update = useCallback(async () => {
+    const res = await querySources(identifier)
+    setResult(res)
+  }, [identifier])
+
+  useEffect(() => {
+    void update()
+  }, [update])
+
+  return result
+}
+
+export default useSources

--- a/src/index.ios.tsx
+++ b/src/index.ios.tsx
@@ -17,6 +17,7 @@ import getRequestStatusForAuthorization from './utils/getRequestStatusForAuthori
 import queryCategorySamples from './utils/queryCategorySamples'
 import queryCorrelationSamples from './utils/queryCorrelationSamples'
 import queryQuantitySamples from './utils/queryQuantitySamples'
+import querySources from './utils/querySources'
 import queryStatisticsForQuantity from './utils/queryStatisticsForQuantity'
 import queryWorkouts from './utils/queryWorkouts'
 import requestAuthorization from './utils/requestAuthorization'
@@ -61,6 +62,7 @@ const Healthkit = {
   queryQuantitySamples,
   queryStatisticsForQuantity,
   queryWorkouts,
+  querySources,
 
   requestAuthorization,
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,17 @@
 import { Platform } from 'react-native'
 
 import {
-  HKAuthorizationRequestStatus, HKBiologicalSex, HKBloodType, HKFitzpatrickSkinType, HKUnits, HKWheelchairUse,
+  HKAuthorizationRequestStatus,
+  HKBiologicalSex,
+  HKBloodType,
+  HKFitzpatrickSkinType,
+  HKUnits,
+  HKWheelchairUse,
 } from './native-types'
 
 import type ReactNativeHealthkit from './index.ios'
 
-const notAvailableError = `[@kingstinct/react-native-healthkit] Platform "${
-  Platform.OS
-}" not supported`
+const notAvailableError = `[@kingstinct/react-native-healthkit] Platform "${Platform.OS}" not supported`
 
 let hasWarned = false
 
@@ -31,29 +34,36 @@ const Healthkit: typeof ReactNativeHealthkit = {
   getBiologicalSex: UnavailableFn(Promise.resolve(HKBiologicalSex.notSet)),
   getBloodType: UnavailableFn(Promise.resolve(HKBloodType.notSet)),
   getDateOfBirth: UnavailableFn(Promise.resolve(new Date(0))),
-  getFitzpatrickSkinType: UnavailableFn(Promise.resolve(HKFitzpatrickSkinType.notSet)),
+  getFitzpatrickSkinType: UnavailableFn(
+    Promise.resolve(HKFitzpatrickSkinType.notSet),
+  ),
   getMostRecentCategorySample: UnavailableFn(Promise.resolve(null)),
   getMostRecentQuantitySample: UnavailableFn(Promise.resolve(null)),
   getMostRecentWorkout: UnavailableFn(Promise.resolve(null)),
   getPreferredUnit: UnavailableFn(Promise.resolve(HKUnits.Count)),
   getPreferredUnits: UnavailableFn(Promise.resolve([])),
-  getRequestStatusForAuthorization: UnavailableFn(Promise.resolve(HKAuthorizationRequestStatus.unknown)),
+  getRequestStatusForAuthorization: UnavailableFn(
+    Promise.resolve(HKAuthorizationRequestStatus.unknown),
+  ),
   getWheelchairUse: UnavailableFn(Promise.resolve(HKWheelchairUse.notSet)),
   getWorkoutRoutes: UnavailableFn(Promise.resolve([])),
   isHealthDataAvailable: async () => Promise.resolve(false),
   queryCategorySamples: UnavailableFn(Promise.resolve([])),
   queryCorrelationSamples: UnavailableFn(Promise.resolve([])),
   queryQuantitySamples: UnavailableFn(Promise.resolve([])),
-  queryStatisticsForQuantity: UnavailableFn(Promise.resolve({
-    averageQuantity: undefined,
-    maximumQuantity: undefined,
-    minimumQuantity: undefined,
-    sumQuantity: undefined,
-    mostRecentQuantity: undefined,
-    mostRecentQuantityDateInterval: undefined,
-    duration: undefined,
-  })),
+  queryStatisticsForQuantity: UnavailableFn(
+    Promise.resolve({
+      averageQuantity: undefined,
+      maximumQuantity: undefined,
+      minimumQuantity: undefined,
+      sumQuantity: undefined,
+      mostRecentQuantity: undefined,
+      mostRecentQuantityDateInterval: undefined,
+      duration: undefined,
+    }),
+  ),
   queryWorkouts: UnavailableFn(Promise.resolve([])),
+  querySources: UnavailableFn(Promise.resolve([])),
   requestAuthorization: UnavailableFn(Promise.resolve(false)),
   deleteQuantitySample: UnavailableFn(Promise.resolve(false)),
   deleteSamples: UnavailableFn(Promise.resolve(false)),
@@ -61,12 +71,17 @@ const Healthkit: typeof ReactNativeHealthkit = {
   saveCorrelationSample: UnavailableFn(Promise.resolve(false)),
   saveQuantitySample: UnavailableFn(Promise.resolve(false)),
   saveWorkoutSample: UnavailableFn(Promise.resolve(false)),
-  subscribeToChanges: UnavailableFn(Promise.resolve(async () => Promise.resolve(false))),
+  subscribeToChanges: UnavailableFn(
+    Promise.resolve(async () => Promise.resolve(false)),
+  ),
   useMostRecentCategorySample: UnavailableFn(null),
   useMostRecentQuantitySample: UnavailableFn(null),
   useMostRecentWorkout: UnavailableFn(null),
   useSubscribeToChanges: UnavailableFn([null, () => null]),
-  useHealthkitAuthorization: UnavailableFn([null, async () => Promise.resolve(HKAuthorizationRequestStatus.unknown)] as const),
+  useHealthkitAuthorization: UnavailableFn([
+    null,
+    async () => Promise.resolve(HKAuthorizationRequestStatus.unknown),
+  ] as const),
   useIsHealthDataAvailable: () => false,
   canAccessProtectedData: async () => Promise.resolve(false),
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,14 @@
 import { Platform } from 'react-native'
 
 import {
-  HKAuthorizationRequestStatus,
-  HKBiologicalSex,
-  HKBloodType,
-  HKFitzpatrickSkinType,
-  HKUnits,
-  HKWheelchairUse,
+  HKAuthorizationRequestStatus, HKBiologicalSex, HKBloodType, HKFitzpatrickSkinType, HKUnits, HKWheelchairUse,
 } from './native-types'
 
 import type ReactNativeHealthkit from './index.ios'
 
-const notAvailableError = `[@kingstinct/react-native-healthkit] Platform "${Platform.OS}" not supported`
+const notAvailableError = `[@kingstinct/react-native-healthkit] Platform "${
+  Platform.OS
+}" not supported`
 
 let hasWarned = false
 
@@ -34,34 +31,28 @@ const Healthkit: typeof ReactNativeHealthkit = {
   getBiologicalSex: UnavailableFn(Promise.resolve(HKBiologicalSex.notSet)),
   getBloodType: UnavailableFn(Promise.resolve(HKBloodType.notSet)),
   getDateOfBirth: UnavailableFn(Promise.resolve(new Date(0))),
-  getFitzpatrickSkinType: UnavailableFn(
-    Promise.resolve(HKFitzpatrickSkinType.notSet),
-  ),
+  getFitzpatrickSkinType: UnavailableFn(Promise.resolve(HKFitzpatrickSkinType.notSet)),
   getMostRecentCategorySample: UnavailableFn(Promise.resolve(null)),
   getMostRecentQuantitySample: UnavailableFn(Promise.resolve(null)),
   getMostRecentWorkout: UnavailableFn(Promise.resolve(null)),
   getPreferredUnit: UnavailableFn(Promise.resolve(HKUnits.Count)),
   getPreferredUnits: UnavailableFn(Promise.resolve([])),
-  getRequestStatusForAuthorization: UnavailableFn(
-    Promise.resolve(HKAuthorizationRequestStatus.unknown),
-  ),
+  getRequestStatusForAuthorization: UnavailableFn(Promise.resolve(HKAuthorizationRequestStatus.unknown)),
   getWheelchairUse: UnavailableFn(Promise.resolve(HKWheelchairUse.notSet)),
   getWorkoutRoutes: UnavailableFn(Promise.resolve([])),
   isHealthDataAvailable: async () => Promise.resolve(false),
   queryCategorySamples: UnavailableFn(Promise.resolve([])),
   queryCorrelationSamples: UnavailableFn(Promise.resolve([])),
   queryQuantitySamples: UnavailableFn(Promise.resolve([])),
-  queryStatisticsForQuantity: UnavailableFn(
-    Promise.resolve({
-      averageQuantity: undefined,
-      maximumQuantity: undefined,
-      minimumQuantity: undefined,
-      sumQuantity: undefined,
-      mostRecentQuantity: undefined,
-      mostRecentQuantityDateInterval: undefined,
-      duration: undefined,
-    }),
-  ),
+  queryStatisticsForQuantity: UnavailableFn(Promise.resolve({
+    averageQuantity: undefined,
+    maximumQuantity: undefined,
+    minimumQuantity: undefined,
+    sumQuantity: undefined,
+    mostRecentQuantity: undefined,
+    mostRecentQuantityDateInterval: undefined,
+    duration: undefined,
+  })),
   queryWorkouts: UnavailableFn(Promise.resolve([])),
   querySources: UnavailableFn(Promise.resolve([])),
   requestAuthorization: UnavailableFn(Promise.resolve(false)),
@@ -71,17 +62,12 @@ const Healthkit: typeof ReactNativeHealthkit = {
   saveCorrelationSample: UnavailableFn(Promise.resolve(false)),
   saveQuantitySample: UnavailableFn(Promise.resolve(false)),
   saveWorkoutSample: UnavailableFn(Promise.resolve(false)),
-  subscribeToChanges: UnavailableFn(
-    Promise.resolve(async () => Promise.resolve(false)),
-  ),
+  subscribeToChanges: UnavailableFn(Promise.resolve(async () => Promise.resolve(false))),
   useMostRecentCategorySample: UnavailableFn(null),
   useMostRecentQuantitySample: UnavailableFn(null),
   useMostRecentWorkout: UnavailableFn(null),
   useSubscribeToChanges: UnavailableFn([null, () => null]),
-  useHealthkitAuthorization: UnavailableFn([
-    null,
-    async () => Promise.resolve(HKAuthorizationRequestStatus.unknown),
-  ] as const),
+  useHealthkitAuthorization: UnavailableFn([null, async () => Promise.resolve(HKAuthorizationRequestStatus.unknown)] as const),
   useIsHealthDataAvailable: () => false,
   canAccessProtectedData: async () => Promise.resolve(false),
 }

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -2,7 +2,7 @@ import { NativeModule, NativeModules } from 'react-native'
 
 import type Native from './native-types'
 
-const mockModule: (NativeModule & typeof Native) = {
+const mockModule: NativeModule & typeof Native = {
   isHealthDataAvailable: jest.fn(),
   addListener: jest.fn(),
   removeListeners: jest.fn(),
@@ -25,6 +25,7 @@ const mockModule: (NativeModule & typeof Native) = {
   queryCategorySamples: jest.fn(),
   queryCorrelationSamples: jest.fn(),
   queryQuantitySamples: jest.fn(),
+  querySources: jest.fn(),
   queryStatisticsForQuantity: jest.fn(),
   queryWorkoutSamples: jest.fn(),
   saveCategorySample: jest.fn(),

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -2,7 +2,7 @@ import { NativeModule, NativeModules } from 'react-native'
 
 import type Native from './native-types'
 
-const mockModule: NativeModule & typeof Native = {
+const mockModule: (NativeModule & typeof Native) = {
   isHealthDataAvailable: jest.fn(),
   addListener: jest.fn(),
   removeListeners: jest.fn(),

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -495,7 +495,7 @@ export enum HKCategoryValueSleepAnalysis {
   awake = 2,
   asleepCore = 3,
   asleepDeep = 4,
-  asleepREM = 5,
+  asleepREM = 5
 }
 
 export enum HKCategoryValueAppetiteChanges {
@@ -1214,7 +1214,7 @@ type ReactNativeHealthkitTypeNative = {
   readonly deleteSamples: <TIdentifier extends HKQuantityTypeIdentifier>(
     identifier: TIdentifier,
     start: string,
-    end: string
+    end: string,
   ) => Promise<boolean>;
   readonly queryWorkoutSamples: <
     TEnergy extends EnergyUnit,

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -127,7 +127,6 @@ export enum HKQuantityTypeIdentifier {
   waterTemperature = 'HKQuantityTypeIdentifierWaterTemperature', // Temperature, Discrete
 
   appleSleepingWristTemperature = 'HKQuantityTypeIdentifierAppleSleepingWristTemperature', // Temperature, Discrete
-
 }
 
 export type TypeToUnitMapping = {
@@ -496,7 +495,7 @@ export enum HKCategoryValueSleepAnalysis {
   awake = 2,
   asleepCore = 3,
   asleepDeep = 4,
-  asleepREM = 5
+  asleepREM = 5,
 }
 
 export enum HKCategoryValueAppetiteChanges {
@@ -1215,7 +1214,7 @@ type ReactNativeHealthkitTypeNative = {
   readonly deleteSamples: <TIdentifier extends HKQuantityTypeIdentifier>(
     identifier: TIdentifier,
     start: string,
-    end: string,
+    end: string
   ) => Promise<boolean>;
   readonly queryWorkoutSamples: <
     TEnergy extends EnergyUnit,
@@ -1246,6 +1245,11 @@ type ReactNativeHealthkitTypeNative = {
     limit: number,
     ascending: boolean
   ) => Promise<readonly HKQuantitySampleRaw<TIdentifier, TUnit>[]>;
+  readonly querySources: <
+    TIdentifier extends HKCategoryTypeIdentifier | HKQuantityTypeIdentifier
+  >(
+    identifier: TIdentifier
+  ) => Promise<readonly HKSource[]>;
   readonly saveCategorySample: <T extends HKCategoryTypeIdentifier>(
     identifier: T,
     value: HKCategoryValueForIdentifier<T>,

--- a/src/utils/querySources.ts
+++ b/src/utils/querySources.ts
@@ -1,0 +1,21 @@
+import Native from '../native-types'
+
+import type {
+  HKQuantityTypeIdentifier,
+  HKSource,
+  HKCategoryTypeIdentifier,
+} from '../native-types'
+
+export type QuerySourcesFn = <
+  TIdentifier extends HKCategoryTypeIdentifier | HKQuantityTypeIdentifier
+>(
+  identifier: TIdentifier
+) => Promise<readonly HKSource[]>;
+
+const querySources: QuerySourcesFn = async (identifier) => {
+  const quantitySamples = await Native.querySources(identifier)
+
+  return quantitySamples
+}
+
+export default querySources


### PR DESCRIPTION
This PR adds new function for fetching the sources that have been used to save HealthKit samples:

- query sources with `HKCategoryTypeIdentifier` or `HKQuantityTypeIdentifier` 
- new `querySources` function for fetching sources, returns a list of source objects that contain name and bundleId of the source
- new `useSources` hook 
- new sources section in the test app with examples on fetching both  `HKCategoryTypeIdentifier` and `HKQuantityTypeIdentifier` sources

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-03 at 00 41 09](https://user-images.githubusercontent.com/7436554/210282616-e4062043-e8cd-46bc-8437-c4e893fb6664.png)
