### PR TITLE
chore: remove jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -33,7 +33,6 @@ android {
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
-    
   }
   
   buildTypes {
@@ -52,7 +51,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   def found = false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-ReactNativeHealthkit_kotlinVersion=1.3.50
+ReactNativeHealthkit_kotlinVersion=1.8.10
 ReactNativeHealthkit_compileSdkVersion=28
 ReactNativeHealthkit_buildToolsVersion=28.0.3
 ReactNativeHealthkit_targetSdkVersion=28


### PR DESCRIPTION
@robertherber hi. I was getting errors with the android build and thought we need to apply these changes in order to not break the apps. But since this library doesn't provide any API for android side, I am wondering the reason for keeping the android files.

Meanwhile, on the user side, I think it's better to disable the autolinking for android by adding this configuration to `react-native.config.js`. 

```js
module.exports = {
  dependencies: {
    '@kingstinct/react-native-healthkit': {
      platforms: {
        android: null
      }
    }
  }
};
```