### PR TITLE
feat: exposing HKHeartbeatSeriesQuery for Heartbeat series data

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,6 +13,7 @@ import useSources from '@kingstinct/react-native-healthkit/hooks/useSources'
 import useStatisticsForQuantity from '@kingstinct/react-native-healthkit/hooks/useStatisticsForQuantity'
 import deleteQuantitySample from '@kingstinct/react-native-healthkit/utils/deleteQuantitySample'
 import deleteSamples from '@kingstinct/react-native-healthkit/utils/deleteSamples'
+import queryHeartbeatSeriesSamples from '@kingstinct/react-native-healthkit/utils/queryHeartbeatSeriesSamples'
 import queryQuantitySamples from '@kingstinct/react-native-healthkit/utils/queryQuantitySamples'
 import saveQuantitySample from '@kingstinct/react-native-healthkit/utils/saveQuantitySample'
 import saveWorkoutSample from '@kingstinct/react-native-healthkit/utils/saveWorkoutSample'
@@ -569,6 +570,8 @@ const readPermissions: readonly HealthkitReadAuthorization[] = [
   HKQuantityTypeIdentifier.distanceWalkingRunning,
   HKQuantityTypeIdentifier.oxygenSaturation,
   HKQuantityTypeIdentifier.heartRate,
+  HKQuantityTypeIdentifier.heartRateVariabilitySDNN,
+  'HKDataTypeIdentifierHeartbeatSeries',
   HKQuantityTypeIdentifier.swimmingStrokeCount,
   HKQuantityTypeIdentifier.bodyFatPercentage,
   HKQuantityTypeIdentifier.bodyMass,
@@ -596,6 +599,7 @@ const App = () => {
   }, [])
 
   const anchor = useRef<string>()
+  const heartbeatsAnchor = useRef<string>()
 
   return status !== HKAuthorizationRequestStatus.unnecessary ? (
     <View style={styles.buttonWrapper}>
@@ -628,6 +632,20 @@ const App = () => {
         }}
         >
           Next 2 stepCount
+        </Button>
+        <Button onPress={async () => {
+          const res = await queryHeartbeatSeriesSamples({
+            limit: 2,
+            anchor: heartbeatsAnchor.current,
+            ascending: true,
+          })
+
+          heartbeatsAnchor.current = res.newAnchor
+
+          alert(JSON.stringify(res))
+        }}
+        >
+          Next 2 HeartbeatSeries samples
         </Button>
         <LatestWorkout icon='run' title='Latest workout' />
         <List.AccordionGroup>

--- a/ios/ReactNativeHealthkit.m
+++ b/ios/ReactNativeHealthkit.m
@@ -99,6 +99,15 @@ RCT_EXTERN_METHOD(queryWorkoutSamples:(NSString)energyUnitString
                   reject:(RCTPromiseRejectBlock)reject
 )
 
+RCT_EXTERN_METHOD(queryHeartbeatSeriesSamples:(NSDate)from
+                  to:(NSDate)to
+                  limit:(NSInteger)limit
+                  ascending:(BOOL)ascending
+                  anchor:(NSString)anchor
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject
+)
+
 RCT_EXTERN_METHOD(queryCategorySamples:(NSString)typeIdentifier
                   from:(NSDate)from
                   to:(NSDate)to

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -5,6 +5,8 @@ let INIT_ERROR = "HEALTHKIT_INIT_ERROR"
 let INIT_ERROR_MESSAGE = "HealthKit not initialized"
 let TYPE_IDENTIFIER_ERROR = "HEALTHKIT_TYPE_IDENTIFIER_NOT_RECOGNIZED_ERROR"
 let GENERIC_ERROR = "HEALTHKIT_ERROR"
+let HEARTBEAT_ERROR = "HEARTBEAT_ERROR"
+let HEARTBEAT_ERROR_MESSAGE = "Failed to retrieve HeartbeatSeries samples."
 
 let HKCharacteristicTypeIdentifier_PREFIX = "HKCharacteristicTypeIdentifier"
 let HKQuantityTypeIdentifier_PREFIX = "HKQuantityTypeIdentifier"
@@ -1419,6 +1421,150 @@ class ReactNativeHealthkit: RCTEventEmitter {
             }
             catch {
                 reject("WORKOUT_LOCATION_ERROR", "Failed to retrieve workout locations", nil)
+            }
+        }
+    }
+
+    typealias HKAnchoredQueryResult = (samples: [HKSample], deletedSamples: [HKDeletedObject]?, newAnchor: HKQueryAnchor?);
+
+    @available(iOS 13.0.0, *)
+    func _queryHeartbeatSeriesSamples(
+        store: HKHealthStore,
+        predicate: NSPredicate?,
+        limit: Int,
+        anchor: HKQueryAnchor?
+    ) async throws -> HKAnchoredQueryResult? {
+        let queryResult = try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<HKAnchoredQueryResult, Error>) in
+            
+            let query = HKAnchoredObjectQuery(
+                type: HKSeriesType.heartbeat(),
+                predicate: predicate,
+                anchor: anchor,
+                limit: limit
+            ) { (
+                query: HKAnchoredObjectQuery,
+                s: [HKSample]?,
+                deletedSamples: [HKDeletedObject]?,
+                newAnchor: HKQueryAnchor?,
+                error: Error?
+            ) in
+                if let err = error {
+                    continuation.resume(throwing: err);
+                    return;
+                }
+
+                guard let samples = s else {
+                    fatalError("Should not fail");
+                }
+                                
+                continuation.resume(returning: HKAnchoredQueryResult(samples: samples, deletedSamples: deletedSamples, newAnchor: newAnchor));
+            }
+            
+            store.execute(query);
+        }
+
+        return queryResult;
+    }
+
+    @available(iOS 13.0.0, *)
+    func getHeartbeatSeriesHeartbeats(store: HKHealthStore, sample: HKHeartbeatSeriesSample) async throws -> [Dictionary<String, Any>]? {
+        let beatTimes = try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<[Dictionary<String, Any>], Error>) in
+            var allBeats: [Dictionary<String, Any>] = [];
+
+            let query = HKHeartbeatSeriesQuery(heartbeatSeries: sample) { (
+                query: HKHeartbeatSeriesQuery,
+                timeSinceSeriesStart: TimeInterval,
+                precededByGap: Bool,
+                done: Bool,
+                error: Error?
+            ) in
+                if let err = error {
+                    continuation.resume(throwing: err);
+                    return;
+                }
+
+                let timeDict: Dictionary<String, Any> = [
+                    "timeSinceSeriesStart": timeSinceSeriesStart,
+                    "precededByGap": precededByGap
+                ];
+                
+                allBeats.append(timeDict);
+
+                if done {
+                    continuation.resume(returning: allBeats);
+                }
+            }
+            
+            store.execute(query);
+        }
+        
+        return beatTimes;
+    }
+
+    @available(iOS 13.0.0, *)
+    func getSerializedHeartbeatSeriesSample(store: HKHealthStore, sample: HKHeartbeatSeriesSample) async throws -> Dictionary<String, Any> {
+        let sampleMetadata = self.serializeMetadata(metadata: sample.metadata) as! Dictionary<String, Any>;
+        let sampleHeartbeats = try await getHeartbeatSeriesHeartbeats(store: store, sample: sample);
+
+        return [
+            "uuid": sample.uuid.uuidString,
+            "device": self.serializeDevice(_device: sample.device) as Any,
+            "startDate": self._dateFormatter.string(from: sample.startDate),
+            "endDate": self._dateFormatter.string(from: sample.endDate),
+            "heartbeats": sampleHeartbeats as Any,
+            "metadata": self.serializeMetadata(metadata: sample.metadata),
+            "sourceRevision": self.serializeSourceRevision(_sourceRevision: sample.sourceRevision) as Any
+        ];
+    }
+
+    @available(iOS 13.0.0, *)
+    @objc(queryHeartbeatSeriesSamples:to:limit:ascending:anchor:resolve:reject:)
+    func queryHeartbeatSeriesSamples(
+        from: Date,
+        to: Date,
+        limit: Int,
+        ascending: Bool,
+        anchor: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard let store = _store else {
+            return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil);
+        }
+
+        Task {
+            do {
+                let from = from.timeIntervalSince1970 > 0 ? from : nil;
+                let to = to.timeIntervalSince1970 > 0 ? to : nil;
+                
+                let predicate = from != nil || to != nil ? HKQuery.predicateForSamples(withStart: from, end: to, options: [HKQueryOptions.strictEndDate, HKQueryOptions.strictStartDate]) : nil;
+                
+                let limit = limit == 0 ? HKObjectQueryNoLimit : limit;
+                
+                let actualAnchor = anchor.isEmpty ? nil : base64StringToHKQueryAnchor(base64String: anchor);
+                
+                let _queryResult = try await _queryHeartbeatSeriesSamples(store: store, predicate: predicate, limit: limit, anchor: actualAnchor);
+                
+                guard let queryResult = _queryResult, let samples = queryResult.samples as! [HKHeartbeatSeriesSample]? else {
+                    return reject(HEARTBEAT_ERROR, HEARTBEAT_ERROR_MESSAGE, nil);
+                }
+                
+                var allHeartbeatSamples: [Dictionary<String, Any>] = [];
+                for sample in samples {
+                    allHeartbeatSamples.append(try await getSerializedHeartbeatSeriesSample(store: store, sample: sample));
+                }
+                
+                resolve([
+                  "samples": allHeartbeatSamples as Any,
+                  "deletedSamples": queryResult.deletedSamples?.map({ sample in
+                    return serializeDeletedSample(sample: sample)
+                  }) as Any,
+                  "newAnchor": serializeAnchor(anchor: queryResult.newAnchor) as Any
+                ]);
+            } catch {
+                reject(HEARTBEAT_ERROR, HEARTBEAT_ERROR_MESSAGE, nil);
             }
         }
     }

--- a/src/index.ios.tsx
+++ b/src/index.ios.tsx
@@ -16,6 +16,7 @@ import getPreferredUnits from './utils/getPreferredUnits'
 import getRequestStatusForAuthorization from './utils/getRequestStatusForAuthorization'
 import queryCategorySamples from './utils/queryCategorySamples'
 import queryCorrelationSamples from './utils/queryCorrelationSamples'
+import queryHeartbeatSeriesSamples from './utils/queryHeartbeatSeriesSamples'
 import queryQuantitySamples from './utils/queryQuantitySamples'
 import querySources from './utils/querySources'
 import queryStatisticsForQuantity from './utils/queryStatisticsForQuantity'
@@ -59,6 +60,7 @@ const Healthkit = {
   // query methods
   queryCategorySamples,
   queryCorrelationSamples,
+  queryHeartbeatSeriesSamples,
   queryQuantitySamples,
   queryStatisticsForQuantity,
   queryWorkouts,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,11 @@ const Healthkit: typeof ReactNativeHealthkit = {
     newAnchor: '',
   })),
   queryCorrelationSamples: UnavailableFn(Promise.resolve([])),
+  queryHeartbeatSeriesSamples: UnavailableFn(Promise.resolve({
+    samples: [],
+    deletedSamples: [],
+    newAnchor: '',
+  })),
   queryQuantitySamples: UnavailableFn(Promise.resolve({
     samples: [],
     deletedSamples: [],

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -24,6 +24,7 @@ const mockModule: (NativeModule & typeof Native) = {
   getWorkoutRoutes: jest.fn(),
   queryCategorySamples: jest.fn(),
   queryCorrelationSamples: jest.fn(),
+  queryHeartbeatSeriesSamples: jest.fn(),
   queryQuantitySamples: jest.fn(),
   querySources: jest.fn(),
   queryStatisticsForQuantity: jest.fn(),

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -745,6 +745,10 @@ contraceptive = 'HKCategoryTypeIdentifierContraceptive',
   appleWalkingSteadinessEvent = 'HKCategoryTypeIdentifierAppleWalkingSteadinessEvent',
   handwashingEvent = 'HKCategoryTypeIdentifierHandwashingEvent', // HKCategoryValue */
 
+export type HKHeartbeatSeriesSampleMetadata = HKGenericMetadata & {
+  readonly HKMetadataKeyAlgorithmVersion: string;
+}
+
 export type MetadataMapperForCategoryIdentifier<
   T extends HKCategoryTypeIdentifier
 > = T extends HKCategoryTypeIdentifier.sexualActivity
@@ -1024,6 +1028,21 @@ export type HKQuantitySampleRaw<
   readonly sourceRevision?: HKSourceRevision;
 };
 
+export type HKHeartbeatRaw = {
+  readonly timeSinceSeriesStart: number,
+  readonly precededByGap: boolean
+}
+
+export type HKHeartbeatSeriesSampleRaw = {
+  readonly uuid: string;
+  readonly device?: HKDevice;
+  readonly startDate: string;
+  readonly endDate: string;
+  readonly heartbeats: readonly HKHeartbeatRaw[];
+  readonly metadata?: HKHeartbeatSeriesSampleMetadata;
+  readonly sourceRevision?: HKSourceRevision;
+}
+
 export type HKQuantitySampleRawForSaving<
   TQuantityIdentifier extends HKQuantityTypeIdentifier = HKQuantityTypeIdentifier,
   TUnit extends UnitForIdentifier<TQuantityIdentifier> = UnitForIdentifier<TQuantityIdentifier>
@@ -1105,6 +1124,11 @@ export type DeletedCategorySampleRaw<T extends HKCategoryTypeIdentifier> = {
   readonly metadata: MetadataMapperForCategoryIdentifier<T>
 }
 
+export type DeletedHeartbeatSeriesSampleRaw = {
+  readonly uuid: string;
+  readonly metadata: HKHeartbeatSeriesSampleMetadata;
+}
+
 export type DeletedQuantitySampleRaw<T extends HKQuantityTypeIdentifier> = {
   readonly uuid: string;
   readonly metadata: MetadataMapperForQuantityIdentifier<T>
@@ -1113,6 +1137,12 @@ export type DeletedQuantitySampleRaw<T extends HKQuantityTypeIdentifier> = {
 export type QueryCategorySamplesResponseRaw<T extends HKCategoryTypeIdentifier> = {
   readonly samples: readonly HKCategorySampleRaw<T>[],
   readonly deletedSamples: readonly DeletedCategorySampleRaw<T>[],
+  readonly newAnchor: string
+}
+
+export type QueryHeartbeatSeriesSamplesResponseRaw = {
+  readonly samples: readonly HKHeartbeatSeriesSampleRaw[],
+  readonly deletedSamples: readonly DeletedHeartbeatSeriesSampleRaw[],
   readonly newAnchor: string
 }
 
@@ -1258,6 +1288,13 @@ type ReactNativeHealthkitTypeNative = {
     ascending: boolean,
     anchor: string
   ) => Promise<QueryCategorySamplesResponseRaw<T>>;
+  readonly queryHeartbeatSeriesSamples: (
+    from: string,
+    to: string,
+    limit: number,
+    ascending: boolean,
+    anchor: string
+  ) => Promise<QueryHeartbeatSeriesSamplesResponseRaw>;
   readonly queryQuantitySamples: <
     TIdentifier extends HKQuantityTypeIdentifier,
     TUnit extends UnitForIdentifier<TIdentifier>

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import type {
   HKCorrelationRaw,
   HKCorrelationTypeIdentifier,
   HKDevice,
+  HKHeartbeatSeriesSampleRaw,
   HKQuantityTypeIdentifier,
   HKSourceRevision,
   HKUnit,
@@ -44,6 +45,11 @@ export interface HKWorkout<
   TEnergy extends EnergyUnit = EnergyUnit,
   TDistance extends LengthUnit = LengthUnit
 > extends Omit<HKWorkoutRaw<TEnergy, TDistance>, 'endDate' | 'startDate'> {
+  readonly startDate: Date;
+  readonly endDate: Date;
+}
+
+export interface HKHeartbeatSeriesSample extends Omit<HKHeartbeatSeriesSampleRaw, 'endDate' | 'startDate'> {
   readonly startDate: Date;
   readonly endDate: Date;
 }

--- a/src/utils/deserializeHeartbeatSeriesSample.ts
+++ b/src/utils/deserializeHeartbeatSeriesSample.ts
@@ -1,0 +1,12 @@
+import type { HKHeartbeatSeriesSampleRaw } from '../native-types'
+import type { HKHeartbeatSeriesSample } from '../types'
+
+function deserializeHeartbeatSeriesSample(sample: HKHeartbeatSeriesSampleRaw): HKHeartbeatSeriesSample {
+  return {
+    ...sample,
+    startDate: new Date(sample.startDate),
+    endDate: new Date(sample.endDate),
+  }
+}
+
+export default deserializeHeartbeatSeriesSample

--- a/src/utils/queryHeartbeatSeriesSamples.ts
+++ b/src/utils/queryHeartbeatSeriesSamples.ts
@@ -1,0 +1,34 @@
+import Native from '../native-types'
+import deserializeHeartbeatSeriesSample from './deserializeHeartbeatSeriesSample'
+import prepareOptions from './prepareOptions'
+
+import type { DeletedHeartbeatSeriesSampleRaw } from '../native-types'
+import type { GenericQueryOptions, HKHeartbeatSeriesSample } from '../types'
+
+export type QueryHeartbeatSeriesSamplesResponse = {
+  readonly samples: readonly HKHeartbeatSeriesSample[],
+  readonly deletedSamples: readonly DeletedHeartbeatSeriesSampleRaw[],
+  readonly newAnchor: string
+}
+
+export type QueryHeartbeatSeriesSamplesFn = (options: GenericQueryOptions) => Promise<QueryHeartbeatSeriesSamplesResponse>;
+
+const queryHeartbeatSeriesSamples: QueryHeartbeatSeriesSamplesFn = async (options) => {
+  const opts = prepareOptions(options)
+
+  const result = await Native.queryHeartbeatSeriesSamples(
+    opts.from,
+    opts.to,
+    opts.limit,
+    opts.ascending,
+    opts.anchor,
+  )
+
+  return {
+    deletedSamples: result.deletedSamples,
+    newAnchor: result.newAnchor,
+    samples: result.samples.map(deserializeHeartbeatSeriesSample),
+  }
+}
+
+export default queryHeartbeatSeriesSamples


### PR DESCRIPTION
This PR adds functionality to query [`HKHeartbeatSeriesSample`](https://developer.apple.com/documentation/healthkit/hkheartbeatseriessample). Closes #57. 

- To obtain the raw heartbeat data it uses a [`HKHeartbeatSeriesQuery`](https://developer.apple.com/documentation/healthkit/hkheartbeatseriesquery). Another way to do it, which is probably a little more concise, would be using a [`HKHeartbeatSeriesQueryDescriptor`](https://developer.apple.com/documentation/healthkit/hkheartbeatseriesquerydescriptor). However, this requires iOS 15.4 and is not consistent with how the workout routes are currently obtained in the library ([`HKWorkoutRouteQueryDescriptor`](https://developer.apple.com/documentation/healthkit/hkworkoutroutequerydescriptor) also exists).
- Exposes `queryHeartbeatSeriesSamples`.
- Adds a way to test it in the example app by running the anchored query with two samples at a time (see below).
- Deeper integration in the rest of the library (e.g., `deleteSamples`) needs a bit of reworking in the types and partially also the Swift code, as `HKDataTypeIdentifierHeartbeatSeries` is not a `HKQuantityTypeIdentifier`, so this probably warrants a separate PR.

![new_example_button](https://user-images.githubusercontent.com/22620586/234109625-5503c023-55d8-47bb-92ac-20cf817979cc.PNG) ![new_example_alert](https://user-images.githubusercontent.com/22620586/234109685-aaa2ceae-2326-4913-9213-9a02d8ef1268.PNG)
