### PR TITLE
Change entitlements in config plugin

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -40,7 +40,10 @@ const {
  */
 const withEntitlementsPlugin = (config, { background }) => withEntitlementsPlist(config, (config) => {
   config.modResults['com.apple.developer.healthkit'] = true
-  config.modResults['com.apple.developer.healthkit.background-delivery'] = background !== false
+  config.modResults['com.apple.developer.healthkit.access'] = []
+  if(background){
+    config.modResults['com.apple.developer.healthkit.background-delivery'] = true
+  }
   return config
 })
 


### PR DESCRIPTION
It looks like xcode adds different entitlements when you add healthkit manually compared to the expo plugin, which causes a crash during archiving or on EAS build.

This seems like a better entitlement structure that fixes the issue.
