### PR TITLE
Update `authorizationStatusFor` return type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native'
 
 import {
-  HKAuthorizationRequestStatus, HKBiologicalSex, HKBloodType, HKFitzpatrickSkinType, HKQuantityTypeIdentifier, HKUnits, HKWheelchairUse, QueryQuantitySamplesResponseRaw,
+  HKAuthorizationRequestStatus, HKAuthorizationStatus, HKBiologicalSex, HKBloodType, HKFitzpatrickSkinType, HKQuantityTypeIdentifier, HKUnits, HKWheelchairUse, QueryQuantitySamplesResponseRaw,
 } from './native-types'
 
 import type ReactNativeHealthkit from './index.ios'
@@ -24,7 +24,7 @@ function UnavailableFn<T = unknown>(retVal: T) {
 }
 
 const Healthkit: typeof ReactNativeHealthkit = {
-  authorizationStatusFor: UnavailableFn(Promise.resolve(false)),
+  authorizationStatusFor: UnavailableFn(Promise.resolve(HKAuthorizationStatus.notDetermined)),
   disableAllBackgroundDelivery: UnavailableFn(Promise.resolve(false)),
   disableBackgroundDelivery: UnavailableFn(Promise.resolve(false)),
   enableBackgroundDelivery: UnavailableFn(Promise.resolve(false)),

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -1240,7 +1240,7 @@ type ReactNativeHealthkitTypeNative = {
     identifier: HKSampleTypeIdentifier
   ): Promise<QueryId>;
   unsubscribeQuery(queryId: QueryId): Promise<boolean>;
-  authorizationStatusFor(type: HealthkitReadAuthorization): Promise<boolean>;
+  authorizationStatusFor(type: HealthkitReadAuthorization): Promise<HKAuthorizationStatus>;
   getRequestStatusForAuthorization(
     write: WritePermissions,
     read: ReadPermissions


### PR DESCRIPTION
Closes #61

Updates the definition of `authorizationStatusFor` to return a `HKAuthorizationStatus` (instead of a `boolean`) as per the underlying HealthKit method's [documentation](https://developer.apple.com/documentation/healthkit/hkhealthstore/1614154-authorizationstatusfortype).