### PR TITLE
Add more workout details to queryWorkoutSamples

### DIFF
--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -1,6 +1,9 @@
 import HealthKit
 import CoreLocation
+
+#if canImport(WorkoutKit)
 import WorkoutKit
+#endif
 
 @objc(ReactNativeHealthkit)
 @available(iOS 10.0, *)
@@ -709,6 +712,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
                             dict.setValue(serializeQuantity(unit: HKUnit.count(), quantity: workout.totalFlightsClimbed), forKey: "totalFlightsClimbed")
                         }
                         
+                        #if canImport(WorkoutKit)
                         if #available(iOS 17.0, *) {
                             do {
                                 let workoutplan = try await workout.workoutPlan
@@ -719,6 +723,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
                                 // handle error
                             }
                         }
+                        #endif
                         
                         arr.add(dict)
                     }

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -694,7 +694,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
                                         activityStartDate = self._dateFormatter.string(from: activity.startDate)
                                     }
                                     if let end = activity.endDate as Date? {
-                                        activityEndDate = self._dateFormatter.string(from: activity.endDate)
+                                        activityEndDate = self._dateFormatter.string(from: activity.endDate!)
                                     }
                                     let activityDict: [String: Any] = [
                                         "startDate": activityStartDate,

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -714,8 +714,14 @@ class ReactNativeHealthkit: RCTEventEmitter {
                                     if let start = activity.startDate as Date? {
                                         activityStartDate = self._dateFormatter.string(from: activity.startDate)
                                     }
+                                    if let end = activity.endDate as Date? {
+                                        activityEndDate = self._dateFormatter.string(from: activity.endDate)
+                                    }
                                     let activityDict: [String: Any] = [
                                         "startDate": activityStartDate,
+                                        "endDate": activityEndDate,
+                                        "uuid": activity.uuid.uuidString,
+                                        "duration": activity.duration
                                     ]
                                     activitiesDicts.append(activityDict)
                                 }

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -640,9 +640,6 @@ class ReactNativeHealthkit: RCTEventEmitter {
                     return resolve([])
                 }
                 let arr: NSMutableArray = []
-                //create counts for completed workouts so that we can resolve the promise when all workouts have been serialized
-                var completedWorkoutCount = 0
-                let totalWorkouts = samples.count
                 
                 for s in samples {
                     if let workout = s as? HKWorkout {

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -616,20 +616,6 @@ class ReactNativeHealthkit: RCTEventEmitter {
         store.execute(query)
     }
 
-    //Helper function with completions so that async fetching of workout plan can be done
-    @available(iOS 17.0, *)
-    func fetchWorkoutPlan(for workout: HKWorkout, completion: @escaping (WorkoutPlan?) -> Void) {
-        Task {
-            do {
-                let workoutplan = try await workout.workoutPlan
-                completion(workoutplan)
-            } catch {
-                print("Error: \(error)")
-                completion(nil)
-            }
-        }
-    }
-
     @objc(queryWorkoutSamples:distanceUnitString:from:to:limit:ascending:resolve:reject:)
     func queryWorkoutSamples(energyUnitString: String, distanceUnitString: String, from: Date, to: Date, limit: Int, ascending: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         
@@ -730,7 +716,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
                         
                         if #available(iOS 17.0, *) {
                             do {
-                                let workoutplan = try await self.fetchWorkoutPlan(for: workout)
+                                let workoutplan = try await workout.workoutPlan
                                 if let workoutplanId = workoutplan?.id {
                                     dict["workoutPlanId"] = workoutplanId.uuidString
                                 }

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -1,5 +1,6 @@
 import HealthKit
 import CoreLocation
+import WorkoutKit
 
 @objc(ReactNativeHealthkit)
 @available(iOS 10.0, *)
@@ -615,8 +616,23 @@ class ReactNativeHealthkit: RCTEventEmitter {
         store.execute(query)
     }
 
+    //Helper function with completions so that async fetching of workout plan can be done
+    @available(iOS 17.0, *)
+    func fetchWorkoutPlan(for workout: HKWorkout, completion: @escaping (WorkoutPlan?) -> Void) {
+        Task {
+            do {
+                let workoutplan = try await workout.workoutPlan
+                completion(workoutplan)
+            } catch {
+                print("Error: \(error)")
+                completion(nil)
+            }
+        }
+    }
+
     @objc(queryWorkoutSamples:distanceUnitString:from:to:limit:ascending:resolve:reject:)
     func queryWorkoutSamples(energyUnitString: String, distanceUnitString: String, from: Date, to: Date, limit: Int, ascending: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        
         guard let store = _store else {
             return reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil)
         }
@@ -632,18 +648,28 @@ class ReactNativeHealthkit: RCTEventEmitter {
         let distanceUnit = HKUnit.init(from: distanceUnitString)
 
         let q = HKSampleQuery(sampleType: .workoutType(), predicate: predicate, limit: limit, sortDescriptors: getSortDescriptors(ascending: ascending)) { (_: HKSampleQuery, sample: [HKSample]?, error: Error?) in
-            guard let err = error else {
+
+                //check for an error
+                if let err = error {
+                    reject(GENERIC_ERROR, err.localizedDescription, err)
+                    return
+                }
+                
                 guard let samples = sample else {
                     return resolve([])
                 }
                 let arr: NSMutableArray = []
+                //create counts for completed workouts so that we can resolve the promise when all workouts have been serialized
+                var completedWorkoutCount = 0
+                let totalWorkouts = samples.count
 
                 for s in samples {
                     if let workout = s as? HKWorkout {
                         let endDate = self._dateFormatter.string(from: workout.endDate)
                         let startDate = self._dateFormatter.string(from: workout.startDate)
 
-                        let dict: NSMutableDictionary = [
+
+                        var dict: NSMutableDictionary = [
                             "uuid": workout.uuid.uuidString,
                             "device": serializeDevice(_device: workout.device) as Any,
                             "duration": workout.duration,
@@ -657,17 +683,71 @@ class ReactNativeHealthkit: RCTEventEmitter {
                             "sourceRevision": serializeSourceRevision(_sourceRevision: workout.sourceRevision) as Any
                         ]
 
+                        //this is used for our laps functionality to get markers 
+                        //https://developer.apple.com/documentation/healthkit/hkworkoutevent
+                        if let events = workout.workoutEvents {
+                            var eventDicts: [[String: Any]] = []
+                            for event in events {
+                                let eventStartDate = self._dateFormatter.string(from: event.dateInterval.start)
+                                let eventEndDate = self._dateFormatter.string(from: event.dateInterval.end)
+                                let eventDict: [String: Any] = [
+                                    "type": event.type.rawValue, //https://developer.apple.com/documentation/healthkit/hkworkouteventtype
+                                    "startDate": eventStartDate,
+                                    "endDate": eventEndDate
+                                ]
+                                eventDicts.append(eventDict)
+                            }
+                            dict["events"] = eventDicts
+                        }
+                        
+                        //also used for our laps functionality to get activities for custom workouts defined by the user
+                        //https://developer.apple.com/documentation/healthkit/hkworkout/1615340-init 
+                        //it seems this might be depricated in the latest beta so this might need updating!
+                        var activitiesDicts: [[String: Any]] = []
+                        if #available(iOS 16.0, *) {
+                            let activities: [HKWorkoutActivity] = workout.workoutActivities
+                            
+                            if !activities.isEmpty{
+                                for activity in activities {
+                                    var activityStartDate = ""
+                                    var activityEndDate = ""
+                                    if let start = activity.startDate as Date? {
+                                        activityStartDate = self._dateFormatter.string(from: activity.startDate)
+                                    }
+                                    let activityDict: [String: Any] = [
+                                        "startDate": activityStartDate,
+                                    ]
+                                    activitiesDicts.append(activityDict)
+                                }
+                            }
+                        }
+                        dict["activities"] = activitiesDicts
+
                         if #available(iOS 11, *) {
                             dict.setValue(serializeQuantity(unit: HKUnit.count(), quantity: workout.totalFlightsClimbed), forKey: "totalFlightsClimbed")
                         }
-
-                        arr.add(dict)
+                        
+                        if #available(iOS 17.0, *) {
+                            self.fetchWorkoutPlan(for: workout) { workoutplan in
+                                if let workoutplanId = workoutplan?.id {
+                                    dict["workoutPlanId"] = workoutplanId.uuidString
+                                }
+                                arr.add(dict)
+                                completedWorkoutCount += 1
+                                //to avoid race condition only resolve when all workouts have been serialized
+                                if completedWorkoutCount == totalWorkouts {
+                                    return resolve(arr)
+                                }
+                            }
+                        } else {
+                            arr.add(dict)
+                            completedWorkoutCount += 1
+                            if completedWorkoutCount == totalWorkouts {
+                                return resolve(arr)
+                            }
+                        }
                     }
                 }
-
-                return resolve(arr)
-            }
-            reject(GENERIC_ERROR, err.localizedDescription, err)
         }
 
         store.execute(q)

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -648,12 +648,7 @@ class ReactNativeHealthkit: RCTEventEmitter {
         let distanceUnit = HKUnit.init(from: distanceUnitString)
 
         let q = HKSampleQuery(sampleType: .workoutType(), predicate: predicate, limit: limit, sortDescriptors: getSortDescriptors(ascending: ascending)) { (_: HKSampleQuery, sample: [HKSample]?, error: Error?) in
-
-                //check for an error
-                if let err = error {
-                    reject(GENERIC_ERROR, err.localizedDescription, err)
-                    return
-                }
+            guard let err = error else {
                 
                 guard let samples = sample else {
                     return resolve([])
@@ -662,14 +657,14 @@ class ReactNativeHealthkit: RCTEventEmitter {
                 //create counts for completed workouts so that we can resolve the promise when all workouts have been serialized
                 var completedWorkoutCount = 0
                 let totalWorkouts = samples.count
-
+                
                 for s in samples {
                     if let workout = s as? HKWorkout {
                         let endDate = self._dateFormatter.string(from: workout.endDate)
                         let startDate = self._dateFormatter.string(from: workout.startDate)
-
-
-                        var dict: NSMutableDictionary = [
+                        
+                        
+                        let dict: NSMutableDictionary = [
                             "uuid": workout.uuid.uuidString,
                             "device": serializeDevice(_device: workout.device) as Any,
                             "duration": workout.duration,
@@ -682,11 +677,11 @@ class ReactNativeHealthkit: RCTEventEmitter {
                             "metadata": serializeMetadata(metadata: workout.metadata),
                             "sourceRevision": serializeSourceRevision(_sourceRevision: workout.sourceRevision) as Any
                         ]
-
-                        //this is used for our laps functionality to get markers 
+                        
+                        //this is used for our laps functionality to get markers
                         //https://developer.apple.com/documentation/healthkit/hkworkoutevent
+                        var eventArray: [[String: Any]] = []
                         if let events = workout.workoutEvents {
-                            var eventDicts: [[String: Any]] = []
                             for event in events {
                                 let eventStartDate = self._dateFormatter.string(from: event.dateInterval.start)
                                 let eventEndDate = self._dateFormatter.string(from: event.dateInterval.end)
@@ -695,15 +690,15 @@ class ReactNativeHealthkit: RCTEventEmitter {
                                     "startDate": eventStartDate,
                                     "endDate": eventEndDate
                                 ]
-                                eventDicts.append(eventDict)
+                                eventArray.append(eventDict)
                             }
-                            dict["events"] = eventDicts
                         }
+                        dict["events"] = eventArray
                         
                         //also used for our laps functionality to get activities for custom workouts defined by the user
-                        //https://developer.apple.com/documentation/healthkit/hkworkout/1615340-init 
+                        //https://developer.apple.com/documentation/healthkit/hkworkout/1615340-init
                         //it seems this might be depricated in the latest beta so this might need updating!
-                        var activitiesDicts: [[String: Any]] = []
+                        var activitiesArray: [[String: Any]] = []
                         if #available(iOS 16.0, *) {
                             let activities: [HKWorkoutActivity] = workout.workoutActivities
                             
@@ -723,39 +718,34 @@ class ReactNativeHealthkit: RCTEventEmitter {
                                         "uuid": activity.uuid.uuidString,
                                         "duration": activity.duration
                                     ]
-                                    activitiesDicts.append(activityDict)
+                                    activitiesArray.append(activityDict)
                                 }
                             }
                         }
-                        dict["activities"] = activitiesDicts
-
+                        dict["activities"] = activitiesArray
+                        
                         if #available(iOS 11, *) {
                             dict.setValue(serializeQuantity(unit: HKUnit.count(), quantity: workout.totalFlightsClimbed), forKey: "totalFlightsClimbed")
                         }
                         
                         if #available(iOS 17.0, *) {
-                            self.fetchWorkoutPlan(for: workout) { workoutplan in
+                            do {
+                                let workoutplan = try await self.fetchWorkoutPlan(for: workout)
                                 if let workoutplanId = workoutplan?.id {
                                     dict["workoutPlanId"] = workoutplanId.uuidString
                                 }
-                                arr.add(dict)
-                                completedWorkoutCount += 1
-                                //to avoid race condition only resolve when all workouts have been serialized
-                                if completedWorkoutCount == totalWorkouts {
-                                    return resolve(arr)
-                                }
-                            }
-                        } else {
-                            arr.add(dict)
-                            completedWorkoutCount += 1
-                            if completedWorkoutCount == totalWorkouts {
-                                return resolve(arr)
+                            } catch {
+                                // handle error
                             }
                         }
+                        
+                        arr.add(dict)
                     }
                 }
+                return resolve(arr)
+            }
+            reject(GENERIC_ERROR, err.localizedDescription, err)
         }
-
         store.execute(q)
     }
 

--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -635,18 +635,16 @@ class ReactNativeHealthkit: RCTEventEmitter {
 
         let q = HKSampleQuery(sampleType: .workoutType(), predicate: predicate, limit: limit, sortDescriptors: getSortDescriptors(ascending: ascending)) { (_: HKSampleQuery, sample: [HKSample]?, error: Error?) in
             guard let err = error else {
-                
                 guard let samples = sample else {
                     return resolve([])
                 }
                 let arr: NSMutableArray = []
-                
+
                 for s in samples {
                     if let workout = s as? HKWorkout {
                         let endDate = self._dateFormatter.string(from: workout.endDate)
                         let startDate = self._dateFormatter.string(from: workout.startDate)
-                        
-                        
+
                         let dict: NSMutableDictionary = [
                             "uuid": workout.uuid.uuidString,
                             "device": serializeDevice(_device: workout.device) as Any,
@@ -725,10 +723,12 @@ class ReactNativeHealthkit: RCTEventEmitter {
                         arr.add(dict)
                     }
                 }
+
                 return resolve(arr)
             }
             reject(GENERIC_ERROR, err.localizedDescription, err)
         }
+
         store.execute(q)
     }
 

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -1747,8 +1747,8 @@ export type HKWorkoutRaw<
   readonly endDate: string;
   readonly metadata?: HKWorkoutMetadata;
   readonly sourceRevision?: HKSourceRevision;
-  readonly events?: HKWorkoutEvent;
-  readonly activities?: HKWorkoutActivity;
+  readonly events?: readonly HKWorkoutEvent[];
+  readonly activities?: readonly HKWorkoutActivity[];
   readonly workoutPlanId?: string;
 };
 

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -670,6 +670,34 @@ export enum HKQuantityTypeIdentifier {
    * @since iOS 16
    */
   heartRateRecoveryOneMinute = 'HKQuantityTypeIdentifierHeartRateRecoveryOneMinute',
+
+  /** 
+   * Running Ground Contact Time
+   * @see {@link https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierrunninggroundcontacttime Apple Docs HKQuantityTypeIdentifierRunningGroundContactTime}
+   * @since iOS 16
+   */
+  runningGroundContactTime = 'HKQuantityTypeIdentifierRunningGroundContactTime',
+
+  /** 
+   * Running Stride Length
+   * @see {@link https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierrunningstridelength Apple Docs HKQuantityTypeIdentifierRunningStrideLength}
+   * @since iOS 16
+   */
+  runningStrideLength = 'HKQuantityTypeIdentifierRunningStrideLength',
+
+  /** 
+   * Running Power
+   * @see {@link https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierrunningpower Apple Docs HKQuantityTypeIdentifierRunningPower}
+   * @since iOS 16
+   */
+  runningPower = 'HKQuantityTypeIdentifierRunningPower',
+
+  /** 
+   * Running Vertical Oscillation
+   * @see {@link https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierrunningverticaloscillation Apple Docs HKQuantityTypeIdentifierRunningVerticalOscillation}
+   * @since iOS 16
+   */
+  runningVerticalOscillation = 'HKQuantityTypeIdentifierRunningVerticalOscillation',
 }
 
 export type TypeToUnitMapping = {
@@ -1673,6 +1701,16 @@ HKCategorySampleRaw<TCategory>,
 'device' | 'endDate' | 'startDate' | 'uuid'
 >;
 
+export interface HKWorkoutEvent {
+  readonly type: string,
+  readonly startDate: string,
+  readonly endDate: string,
+}
+
+export interface HKWorkoutActivity {
+  readonly startDate: string,
+}
+
 export type HKWorkoutRaw<
   TEnergy extends EnergyUnit,
   TDistance extends LengthUnit
@@ -1695,6 +1733,9 @@ export type HKWorkoutRaw<
   readonly endDate: string;
   readonly metadata?: HKWorkoutMetadata;
   readonly sourceRevision?: HKSourceRevision;
+  readonly events?: HKWorkoutEvent;
+  readonly activities?: HKWorkoutActivity;
+  readonly workoutPlanId?: string;
 };
 
 // Straight mapping to https://developer.apple.com/documentation/healthkit/hkcharacteristictypeidentifier

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -1702,13 +1702,27 @@ HKCategorySampleRaw<TCategory>,
 >;
 
 export interface HKWorkoutEvent {
-  readonly type: string,
+  readonly type: HKWorkoutEventType,
   readonly startDate: string,
   readonly endDate: string,
 }
 
+export enum HKWorkoutEventType {
+  pause = 1,
+  resume = 2,
+  lap = 3,
+  marker = 4,
+  motionPaused = 5,
+  motionResumed = 6,
+  segment = 7,
+  pauseOrResumeRequest = 8,
+}
+
 export interface HKWorkoutActivity {
   readonly startDate: string,
+  readonly endDate: string,
+  readonly uuid: string,
+  readonly duration: number,
 }
 
 export type HKWorkoutRaw<

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -9,16 +9,28 @@ import type { EmitterSubscription, NativeModule } from 'react-native'
 export const HKWorkoutTypeIdentifier = 'HKWorkoutTypeIdentifier' as const
 
 /**
- * Represents an audiogram type identifier.
+ * Represents a type that identifies activity summary objects.
+ * @see {@link https://developer.apple.com/documentation/healthkit/hkactivitysummarytype Apple Docs HKActivitySummaryType}
  */
-export const HKAudiogramTypeIdentifier = 'HKAudiogramTypeIdentifier' as const
+export const HKActivitySummaryType = 'HKActivitySummaryType' as const
+
+/**
+ * Represents an audiogram type identifier.
+ * @see {@link https://developer.apple.com/documentation/healthkit/HKAudiogramSampleType Apple Docs HKAudiogramSampleType}
+ */
+export const HKAudiogramTypeIdentifier = 'HKAudiogramSampleType' as const
 
 /**
  * Represents a workout route type identifier.
  * @see {@link https://developer.apple.com/documentation/healthkit/hkworkoutroutetypeidentifier Apple Docs HKWorkoutRouteTypeIdentifier}
  */
 export const HKWorkoutRouteTypeIdentifier = 'HKWorkoutRouteTypeIdentifier' as const
-export const HKDataTypeIdentifierHeartbeatSeries = 'HKDataTypeIdentifierHeartbeatSeries' as const
+
+/**
+ * Represents a series sample containing heartbeat data..
+ * @see {@link https://developer.apple.com/documentation/healthkit/HKDataTypeIdentifierHeartbeatSeries Apple Docs HKDataTypeIdentifierHeartbeatSeries}
+ */
+export declare const HKDataTypeIdentifierHeartbeatSeries: 'HKDataTypeIdentifierHeartbeatSeries'
 
 /**
  * Represents a quantity type identifier.
@@ -698,6 +710,13 @@ export enum HKQuantityTypeIdentifier {
    * @since iOS 16
    */
   runningVerticalOscillation = 'HKQuantityTypeIdentifierRunningVerticalOscillation',
+
+  /**
+   * Running Speed
+   * @see {@link https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierrunningspeed Apple Docs HKQuantityTypeIdentifierRunningSpeed}
+   * @since iOS 16
+   */
+  runningSpeed = 'HKQuantityTypeIdentifierRunningSpeed',
 }
 
 export type TypeToUnitMapping = {
@@ -796,16 +815,7 @@ export enum HKCategoryTypeIdentifier {
 }
 
 export type HKSampleTypeIdentifier =
-  | HKCategoryTypeIdentifier
-  | HKCorrelationTypeIdentifier
-  | HKQuantityTypeIdentifier
-  | typeof HKAudiogramTypeIdentifier
-  | typeof HKDataTypeIdentifierHeartbeatSeries
-  | typeof HKWorkoutRouteTypeIdentifier
-  | typeof HKWorkoutTypeIdentifier
-  | `${HKCategoryTypeIdentifier}`
-  | `${HKCorrelationTypeIdentifier}`
-  | `${HKQuantityTypeIdentifier}`;
+  HKCategoryTypeIdentifier | HKCorrelationTypeIdentifier | HKQuantityTypeIdentifier | typeof HKActivitySummaryType | typeof HKAudiogramTypeIdentifier | typeof HKDataTypeIdentifierHeartbeatSeries | typeof HKWorkoutRouteTypeIdentifier | typeof HKWorkoutTypeIdentifier | `${HKCategoryTypeIdentifier}` | `${HKCorrelationTypeIdentifier}` | `${HKQuantityTypeIdentifier}`;
 
 export type HealthkitReadAuthorization =
   | HKCharacteristicTypeIdentifier

--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -671,28 +671,28 @@ export enum HKQuantityTypeIdentifier {
    */
   heartRateRecoveryOneMinute = 'HKQuantityTypeIdentifierHeartRateRecoveryOneMinute',
 
-  /** 
+  /**
    * Running Ground Contact Time
    * @see {@link https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierrunninggroundcontacttime Apple Docs HKQuantityTypeIdentifierRunningGroundContactTime}
    * @since iOS 16
    */
   runningGroundContactTime = 'HKQuantityTypeIdentifierRunningGroundContactTime',
 
-  /** 
+  /**
    * Running Stride Length
    * @see {@link https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierrunningstridelength Apple Docs HKQuantityTypeIdentifierRunningStrideLength}
    * @since iOS 16
    */
   runningStrideLength = 'HKQuantityTypeIdentifierRunningStrideLength',
 
-  /** 
+  /**
    * Running Power
    * @see {@link https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierrunningpower Apple Docs HKQuantityTypeIdentifierRunningPower}
    * @since iOS 16
    */
   runningPower = 'HKQuantityTypeIdentifierRunningPower',
 
-  /** 
+  /**
    * Running Vertical Oscillation
    * @see {@link https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierrunningverticaloscillation Apple Docs HKQuantityTypeIdentifierRunningVerticalOscillation}
    * @since iOS 16


### PR DESCRIPTION
**Additions to queryWorkoutSamples:**
1. HKWorkoutPlan UUID for WorkoutKit in iOS 17 (https://developer.apple.com/documentation/workoutkit)
- This requires a helper function fetchWorkoutPlan to allow for the fetching of the workout.workoutPlan to be completed asynchronously and return without race conditions in queryWorkoutSamples

2. HKWorkoutEvent such as laps, pause resume - returned with their raw value, start and end timestamp
3. HKWorkoutActivity so that the activities within a custom workout created by the user can be viewed