### PR TITLE
fix: subscribeToObserverQuery not resolving promise

### DIFF
--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -504,6 +504,8 @@ class ReactNativeHealthkit: RCTEventEmitter {
         store.execute(query)
 
         self._runningQueries.updateValue(query, forKey: queryId)
+
+        resolve(queryId)
     }
 
     @objc(unsubscribeQuery:resolve:reject:)


### PR DESCRIPTION
Added resolve(queryId) to the end of subscribeToObserverQuery() so that subscribeToChanges() will return an unsubscribe function