### PR TITLE
Update `queryStatisticsForQuantity` to resolve when competition handler returns `nil` statistics

### DIFF
--- a/ios/ReactNativeHealthkit.swift
+++ b/ios/ReactNativeHealthkit.swift
@@ -673,42 +673,45 @@ class ReactNativeHealthkit: RCTEventEmitter {
         }
 
         let query = HKStatisticsQuery.init(quantityType: quantityType, quantitySamplePredicate: predicate, options: opts) { (_, stats: HKStatistics?, _: Error?) in
-            if let gottenStats = stats {
-                var dic = [String: [String: Any]?]()
-                let unit = HKUnit.init(from: unitString)
-                if let averageQuantity = gottenStats.averageQuantity() {
-                    dic.updateValue(serializeQuantity(unit: unit, quantity: averageQuantity), forKey: "averageQuantity")
-                }
-                if let maximumQuantity = gottenStats.maximumQuantity() {
-                    dic.updateValue(serializeQuantity(unit: unit, quantity: maximumQuantity), forKey: "maximumQuantity")
-                }
-                if let minimumQuantity = gottenStats.minimumQuantity() {
-                    dic.updateValue(serializeQuantity(unit: unit, quantity: minimumQuantity), forKey: "minimumQuantity")
-                }
-                if let sumQuantity = gottenStats.sumQuantity() {
-                    dic.updateValue(serializeQuantity(unit: unit, quantity: sumQuantity), forKey: "sumQuantity")
-                }
-                if #available(iOS 12, *) {
-                    if let mostRecent = gottenStats.mostRecentQuantity() {
-                        dic.updateValue(serializeQuantity(unit: unit, quantity: mostRecent), forKey: "mostRecentQuantity")
-                    }
+            var dic = [String: [String: Any]?]()
 
-                    if let mostRecentDateInterval = gottenStats.mostRecentQuantityDateInterval() {
-                        dic.updateValue([
-                            "start": self._dateFormatter.string(from: mostRecentDateInterval.start),
-                            "end": self._dateFormatter.string(from: mostRecentDateInterval.end)
-                        ], forKey: "mostRecentQuantityDateInterval")
-                    }
-                }
-                if #available(iOS 13, *) {
-                    let durationUnit = HKUnit.second()
-                    if let duration = gottenStats.duration() {
-                        dic.updateValue(serializeQuantity(unit: durationUnit, quantity: duration), forKey: "duration")
-                    }
-                }
-
-                resolve(dic)
+            guard let gottenStats = stats else {
+                return resolve(dic)
             }
+
+            let unit = HKUnit.init(from: unitString)
+            if let averageQuantity = gottenStats.averageQuantity() {
+                dic.updateValue(serializeQuantity(unit: unit, quantity: averageQuantity), forKey: "averageQuantity")
+            }
+            if let maximumQuantity = gottenStats.maximumQuantity() {
+                dic.updateValue(serializeQuantity(unit: unit, quantity: maximumQuantity), forKey: "maximumQuantity")
+            }
+            if let minimumQuantity = gottenStats.minimumQuantity() {
+                dic.updateValue(serializeQuantity(unit: unit, quantity: minimumQuantity), forKey: "minimumQuantity")
+            }
+            if let sumQuantity = gottenStats.sumQuantity() {
+                dic.updateValue(serializeQuantity(unit: unit, quantity: sumQuantity), forKey: "sumQuantity")
+            }
+            if #available(iOS 12, *) {
+                if let mostRecent = gottenStats.mostRecentQuantity() {
+                    dic.updateValue(serializeQuantity(unit: unit, quantity: mostRecent), forKey: "mostRecentQuantity")
+                }
+
+                if let mostRecentDateInterval = gottenStats.mostRecentQuantityDateInterval() {
+                    dic.updateValue([
+                        "start": self._dateFormatter.string(from: mostRecentDateInterval.start),
+                        "end": self._dateFormatter.string(from: mostRecentDateInterval.end)
+                    ], forKey: "mostRecentQuantityDateInterval")
+                }
+            }
+            if #available(iOS 13, *) {
+                let durationUnit = HKUnit.second()
+                if let duration = gottenStats.duration() {
+                    dic.updateValue(serializeQuantity(unit: durationUnit, quantity: duration), forKey: "duration")
+                }
+            }
+
+            resolve(dic)
         }
 
         store.execute(query)


### PR DESCRIPTION
Attempts to resolve https://github.com/kingstinct/react-native-healthkit/issues/78 by calling `resolve` with the newly-created dictionary object when `stats` is `nil`.

Moves from the existing `if let` to a `guard let` based on existing usages elsewhere (for example, [here](https://github.com/kingstinct/react-native-healthkit/blob/3086d95ec7fa6573767e34162f32fd3542fcf5c9/ios/ReactNativeHealthkit.swift#L848-L850)). Thus, the majority of the changes are whitespace, so would recommend viewing the diff [without whitespace](https://github.com/kingstinct/react-native-healthkit/pull/79/files?diff=unified&w=1).