### PR TITLE
Update native-types.ts with latest activity types

### DIFF
--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -916,6 +916,13 @@ export enum HKWorkoutActivityType {
   handCycling = 74,
   discSports = 75,
   fitnessGaming = 76,
+  cardioDance = 77,
+  socialDance = 78,
+  pickleball = 79,
+  cooldown = 80,
+  swimBikeRun = 82,
+  transition = 83,
+  underwaterDiving = 84,
   other = 3000,
 }
 


### PR DESCRIPTION
Add latest HKWorkoutActivityType values to enum.

There doesn't seem to be an 81 (I checked twice).

Got them from [here](https://developer.apple.com/documentation/healthkit/hkworkoutactivitytype).