### PR TITLE
Support new lux HKUnit for iOS 17

### DIFF
--- a/ios/Serializers.swift
+++ b/ios/Serializers.swift
@@ -107,6 +107,12 @@ func serializeUnknownQuantity(quantity: HKQuantity) -> [String: Any]? {
         }
     }
 
+    if #available(iOS 17.0, *) {
+        if quantity.is(compatibleWith: HKUnit.lux()) {
+            return serializeQuantity(unit: HKUnit.lux(), quantity: quantity)
+        }
+    }
+
     if quantity.is(compatibleWith: SpeedUnit) {
         return serializeQuantity(unit: SpeedUnit, quantity: quantity)
     }


### PR DESCRIPTION
iOS 17 added support for the "Time in Daylight" metric that includes a metadata item measured in a new `HKUnit` `HKUnit.lux()`

This adds support for serializing this new unit to make it accessible in React Native as it does not serialize properly otherwise

Some relevant docs:
https://support.apple.com/guide/watch/see-time-in-daylight-apd3ab22534c/watchos
https://developer.apple.com/documentation/healthkit/hkunit/4126896-lux/
https://developer.apple.com/documentation/healthkit/hkmetadatakeymaximumlightintensity/