### PR TITLE
Update native-types.ts

### DIFF
--- a/src/native-types.ts
+++ b/src/native-types.ts
@@ -1545,10 +1545,10 @@ export enum HKUnitMetric {
 export enum HKUnits {
   DecibelHearingLevel = 'dBHL',
   DecibelSoundPressureLevel = 'dBASPL',
-
   Percent = '%',
   Count = 'count',
   InternationalUnit = 'IU',
+  AppleEffortScore = "appleEffortScore"
 }
 
 export type MeterUnit<Prefix extends HKMetricPrefix = HKMetricPrefix.None> =


### PR DESCRIPTION
Add AppleEffortScore as a unit.

From what I can tell, to save workout effort, you need to use this for the unit:

https://developer.apple.com/documentation/healthkit/hkunit/4338085-appleeffortscore

Once this is added, you can now specify a sample as such:

```ts
{
            quantityType: HKQuantityTypeIdentifier.workoutEffortScore,
            unit: "appleEffortScore",
            quantity: effort, // 1-10
 }
```

**Just a warning:** if you plan to add this as a sample to the workout, it won't work.  HealthKit produces an error:

`Error: HKWorkout: Sample of type HKQuantityTypeIdentifierWorkoutEffortScore must be related to a workout`

Related https://github.com/kingstinct/react-native-healthkit/issues/107



