### PR TITLE
Fix Infinite renders/calls for using useSubscribeToChanges

### DIFF
--- a/src/hooks/useStatisticsForQuantity.ts
+++ b/src/hooks/useStatisticsForQuantity.ts
@@ -32,7 +32,7 @@ function useStatisticsForQuantity<TIdentifier extends HKQuantityTypeIdentifier, 
 
   useEffect(() => {
     void update()
-  }, [update])
+  }, [])
 
   useSubscribeToChanges(identifier, update)
 


### PR DESCRIPTION
If we use the same example from the documentation we will have an permanent re-rendering per tick which causes a huge memory leak which with 2 of the same, will crash any app.

Why is this caused?

`update` function is revalue it due  useSubscribeToChanges because `update` have an setResult so the useEffect for the `update` will trigger infinite without even subscribing.

Solution: 
Removing `update` from the dependencies from useEffect will only trigger 1 time so we can have initial values, then we depends totally from useSubscribeToChanges  to trigger `update` which is the porpuse of the subscribing hook.