### PR TITLE
Fix queryCategorySamplesWithAnchor signature

### DIFF
--- a/packages/react-native-healthkit/src/healthkit.ts
+++ b/packages/react-native-healthkit/src/healthkit.ts
@@ -21,6 +21,7 @@ import {
   WheelchairUse,
 } from './types/Characteristics'
 import type { QuantitySample } from './types/QuantitySample'
+import type { QueryOptionsWithAnchor } from './types/QueryOptions'
 
 export * from './types'
 
@@ -185,6 +186,7 @@ export function queryCategorySamplesWithAnchor<
   T extends CategoryTypeIdentifier,
 >(
   _categoryTypeIdentifier: T,
+  _options: QueryOptionsWithAnchor,
 ): Promise<CategorySamplesWithAnchorResponseTyped<T>> {
   if (Platform.OS !== 'ios' && !hasWarned) {
     console.warn(notAvailableError)


### PR DESCRIPTION
Fixes #182

## Summary
- align the `queryCategorySamplesWithAnchor` mock function signature with the spec

## Testing
- `bun x @biomejs/biome check`
- `bun run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6879018a4a88832d8e0022c459e3afc0