### PR TITLE
Increase iOS build timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
   build-ios-beta:
     # Only run on macOS since we need Xcode
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 50
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -146,7 +146,7 @@ jobs:
   build-ios:
     # Only run on macOS since we need Xcode
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 50
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
## Summary
- extend iOS build time for GitHub Actions

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68790c7b7360832dba071f580ffd2c72