### PR TITLE
Fix anchor filtering for statistic collection

### DIFF
--- a/.changeset/blue-kangaroos-mix.md
+++ b/.changeset/blue-kangaroos-mix.md
@@ -1,0 +1,6 @@
+---
+"@kingstinct/react-native-healthkit": patch
+---
+
+- Fix anchor filtering for statistic collection
+- Fix queryCategorySamplesWithAnchor type

--- a/packages/react-native-healthkit/ios/QuantityTypeModule.swift
+++ b/packages/react-native-healthkit/ios/QuantityTypeModule.swift
@@ -306,8 +306,21 @@ class QuantityTypeModule: HybridQuantityTypeModuleSpec {
 
                     var responseArray: [QueryStatisticsResponse] = []
 
-                    // todo: handle from/to here?
-                    statistics.enumerateStatistics(from: Date.distantPast, to: Date()) { stats, _ in
+                    // Limit enumeration to the range in the provided filter if possible
+                    var enumerateFrom = Date.distantPast
+                    var enumerateTo = Date()
+
+                    if let filter = options?.filter {
+                        switch filter {
+                        case .fourth(let dateFilter):
+                            enumerateFrom = dateFilter.startDate ?? enumerateFrom
+                            enumerateTo = dateFilter.endDate ?? enumerateTo
+                        default:
+                            break
+                        }
+                    }
+
+                    statistics.enumerateStatistics(from: enumerateFrom, to: enumerateTo) { stats, _ in
                         var response = QueryStatisticsResponse()
 
                         if let averageQuantity = stats.averageQuantity() {


### PR DESCRIPTION
## Summary
- limit HKStatisticsCollectionQuery enumeration to date range from query filter

## Testing
- `npm test`
- `bun x @biomejs/biome check`


------
https://chatgpt.com/codex/tasks/task_e_6879024c3dec832db9bb2c9fe34fa59b