### PR TITLE
fix: use proper units in queryStatisticsForQuantity to prevent crashes

### DIFF
--- a/.changeset/nasty-phones-shake.md
+++ b/.changeset/nasty-phones-shake.md
@@ -1,0 +1,5 @@
+---
+"@kingstinct/react-native-healthkit": patch
+---
+
+fix: use proper units in queryStatisticsForQuantity to prevent crashes

--- a/packages/react-native-healthkit/ios/QuantityTypeModule.swift
+++ b/packages/react-native-healthkit/ios/QuantityTypeModule.swift
@@ -169,9 +169,9 @@ class QuantityTypeModule: HybridQuantityTypeModuleSpec {
 
         let quantityType = try initializeQuantityType(identifier.stringValue)
         let predicate = try createPredicate(filter: options?.filter)
-        let unit = HKUnit.init(from: options?.unit ?? "count")
 
         return Promise.async {
+            let unit = try await getUnitToUse(unitOverride: options?.unit, quantityType: quantityType)
             return try await withCheckedThrowingContinuation { continuation in
                 let query = HKStatisticsQuery.init(
                     quantityType: quantityType,
@@ -254,7 +254,6 @@ class QuantityTypeModule: HybridQuantityTypeModuleSpec {
         let quantityType = try initializeQuantityType(identifier.stringValue)
 
         let predicate = try createPredicate(filter: options?.filter)
-        let unit = HKUnit.init(from: options?.unit ?? "count")
 
         // Convert the anchor date string to Date
         let dateFormatter = ISO8601DateFormatter()
@@ -284,6 +283,7 @@ class QuantityTypeModule: HybridQuantityTypeModuleSpec {
         let opts = buildStatisticsOptions(statistics: statistics)
 
         return Promise.async {
+            let unit = try await getUnitToUse(unitOverride: options?.unit, quantityType: quantityType)
             return try await withCheckedThrowingContinuation { continuation in
                 let query = HKStatisticsCollectionQuery.init(
                     quantityType: quantityType,


### PR DESCRIPTION
## Summary
- Replace hardcoded "count" unit with `getUnitToUse()` in `queryStatisticsForQuantity` and `queryStatisticsCollectionForQuantity`
- This gets the correct preferred unit for each quantity type, preventing crashes
- Fixes issue where `HKQuantityTypeIdentifierDistanceWalkingRunning` and `HKQuantityTypeIdentifierActiveEnergyBurned` caused app crashes

## Root Cause
The functions were defaulting to "count" unit regardless of quantity type:
- ✅ `HKQuantityTypeIdentifierStepCount` uses "count" → worked fine
- ❌ `HKQuantityTypeIdentifierDistanceWalkingRunning` needs distance units (m, km, mi) → crashed  
- ❌ `HKQuantityTypeIdentifierActiveEnergyBurned` needs energy units (kcal, kJ) → crashed

## Solution
Use the same approach as `queryQuantitySamples` which already works correctly by calling `getUnitToUse()` to get the appropriate unit for each quantity type.

## Test plan
- [ ] Test `queryStatisticsForQuantity` with `HKQuantityTypeIdentifierDistanceWalkingRunning` - should no longer crash
- [ ] Test `queryStatisticsForQuantity` with `HKQuantityTypeIdentifierActiveEnergyBurned` - should no longer crash  
- [ ] Test `queryStatisticsForQuantity` with `HKQuantityTypeIdentifierStepCount` - should continue working
- [ ] Test `queryStatisticsCollectionForQuantity` with various quantity types - should work correctly
- [ ] Verify that when no unit is specified, the proper preferred unit is used automatically
- [ ] Verify that when a unit is explicitly provided, it still works correctly

Fixes #188

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>