### PR TITLE
Update nitro modules

### DIFF
--- a/.changeset/stupid-scissors-study.md
+++ b/.changeset/stupid-scissors-study.md
@@ -1,0 +1,6 @@
+---
+"react-native-healthkit-example": patch
+"@kingstinct/react-native-healthkit": patch
+---
+
+Update nitro modules

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -38,7 +38,7 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
     "react-native-gesture-handler": "~2.24.0",
-    "react-native-nitro-modules": "^0.26.3",
+    "react-native-nitro-modules": "^0.26.4",
     "react-native-reanimated": "~3.17.5",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@types/react": "~19.0.14",
-    "nitro-codegen": "^0.26.3",
+    "nitro-codegen": "^0.26.4",
     "typescript": "~5.8.3"
   },
   "private": true

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
         "react-dom": "19.0.0",
         "react-native": "0.79.5",
         "react-native-gesture-handler": "~2.24.0",
-        "react-native-nitro-modules": "^0.26.3",
+        "react-native-nitro-modules": "^0.26.4",
         "react-native-reanimated": "~3.17.5",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
@@ -56,20 +56,20 @@
       "devDependencies": {
         "@babel/core": "^7.28.0",
         "@types/react": "~19.0.14",
-        "nitro-codegen": "^0.26.3",
+        "nitro-codegen": "^0.26.4",
         "typescript": "~5.8.3",
       },
     },
     "packages/react-native-healthkit": {
       "name": "@kingstinct/react-native-healthkit",
-      "version": "9.0.7",
+      "version": "9.0.10",
       "devDependencies": {
         "@testing-library/react-native": "^13.2.0",
         "@types/react": "~19.0.14",
-        "nitro-codegen": "^0.26.2",
+        "nitro-codegen": "^0.26.4",
         "react": "19.0.0",
         "react-native": "*",
-        "react-native-nitro-modules": "^0.26.2",
+        "react-native-nitro-modules": "^0.26.4",
         "typescript": "~5.8.3",
       },
       "peerDependencies": {
@@ -1292,7 +1292,7 @@
 
     "nested-error-stacks": ["nested-error-stacks@2.0.1", "", {}, "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A=="],
 
-    "nitro-codegen": ["nitro-codegen@0.26.3", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.26.3", "ts-morph": "^25.0.0", "yargs": "^17.7.2", "zod": "^3.23.8" }, "bin": { "nitro-codegen": "lib/index.js" } }, "sha512-hFAjx2hHWNHmX8SLbt6F4KrMfLOWAlcgIe4wGmt9iP/BzSZ/GHPeiI0o28lS52ZzcorvRAy7xjzQgnM1jJ0Amw=="],
+    "nitro-codegen": ["nitro-codegen@0.26.4", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.26.4", "ts-morph": "^25.0.0", "yargs": "^17.7.2", "zod": "^4.0.5" }, "bin": { "nitro-codegen": "lib/index.js" } }, "sha512-qTOvyfE6+kz0wuqPpRlKc6F6ZNOI3elK7ltOTvxMZSG3Y8tt43UrV5xkp4XgL9Jc1P90iBLU6mDYRiNqoNA2+g=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -1756,7 +1756,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.63", "", {}, "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw=="],
+    "zod": ["zod@4.0.10", "", {}, "sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA=="],
 
     "zod-package-json": ["zod-package-json@1.1.0", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-RvEsa3W/NCqEBMtnoE09GRVelA3IqRcKaijEiM6CEGsD19qLurf0HjrYMHwOqImOszlLL0ja63DPJeeU4pm7oQ=="],
 
@@ -1905,6 +1905,8 @@
     "@jest/transform/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "@kingstinct/react-native-healthkit/react-native-nitro-modules": ["react-native-nitro-modules@0.26.4", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-sCZ0U+FY6JM73HaZYyc4kSRV7JQZXGfbimpYJzaAaZFQMGpJFkD5c3Jt66j1v83wN/m6D/SM9yyx+dN6XTfGAg=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -2088,6 +2090,8 @@
 
     "metro-transform-worker/@babel/types": ["@babel/types@7.27.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q=="],
 
+    "nitro-codegen/react-native-nitro-modules": ["react-native-nitro-modules@0.26.4", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-sCZ0U+FY6JM73HaZYyc4kSRV7JQZXGfbimpYJzaAaZFQMGpJFkD5c3Jt66j1v83wN/m6D/SM9yyx+dN6XTfGAg=="],
+
     "ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "ora/cli-cursor": ["cli-cursor@2.1.0", "", { "dependencies": { "restore-cursor": "^2.0.0" } }, "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw=="],
@@ -2102,11 +2106,15 @@
 
     "query-registry/query-string": ["query-string@9.2.0", "", { "dependencies": { "decode-uri-component": "^0.4.1", "filter-obj": "^5.1.0", "split-on-first": "^3.0.0" } }, "sha512-YIRhrHujoQxhexwRLxfy3VSjOXmvZRd2nyw1PwL1UUqZ/ys1dEZd1+NSgXkne2l/4X/7OXkigEAuhTX0g/ivJQ=="],
 
+    "query-registry/zod": ["zod@3.25.63", "", {}, "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw=="],
+
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "react-native/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "react-native-healthkit-example/react-native-nitro-modules": ["react-native-nitro-modules@0.26.4", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-sCZ0U+FY6JM73HaZYyc4kSRV7JQZXGfbimpYJzaAaZFQMGpJFkD5c3Jt66j1v83wN/m6D/SM9yyx+dN6XTfGAg=="],
 
     "react-native-web/@react-native/normalize-colors": ["@react-native/normalize-colors@0.74.89", "", {}, "sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg=="],
 
@@ -2155,6 +2163,8 @@
     "write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "zod-package-json/zod": ["zod@3.25.63", "", {}, "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw=="],
 
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/generator": ["@babel/generator@7.27.5", "", { "dependencies": { "@babel/parser": "^7.27.5", "@babel/types": "^7.27.3", "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25", "jsesc": "^3.0.2" } }, "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1452,7 +1452,7 @@
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.1.7", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w=="],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.26.3", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-M6XXalSeRhz3X44vxlRnmRAcyTfC3EHxKBsAKHRNlTtVyu9IUQeUBBtjtIZgK6CM3km1387buYtRVIg6XGmoGQ=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.26.4", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-sCZ0U+FY6JM73HaZYyc4kSRV7JQZXGfbimpYJzaAaZFQMGpJFkD5c3Jt66j1v83wN/m6D/SM9yyx+dN6XTfGAg=="],
 
     "react-native-reanimated": ["react-native-reanimated@3.17.5", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.0.0-0", "@babel/plugin-transform-class-properties": "^7.0.0-0", "@babel/plugin-transform-classes": "^7.0.0-0", "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0", "@babel/plugin-transform-optional-chaining": "^7.0.0-0", "@babel/plugin-transform-shorthand-properties": "^7.0.0-0", "@babel/plugin-transform-template-literals": "^7.0.0-0", "@babel/plugin-transform-unicode-regex": "^7.0.0-0", "@babel/preset-typescript": "^7.16.7", "convert-source-map": "^2.0.0", "invariant": "^2.2.4", "react-native-is-edge-to-edge": "1.1.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0", "react": "*", "react-native": "*" } }, "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw=="],
 
@@ -1906,8 +1906,6 @@
 
     "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "@kingstinct/react-native-healthkit/react-native-nitro-modules": ["react-native-nitro-modules@0.26.4", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-sCZ0U+FY6JM73HaZYyc4kSRV7JQZXGfbimpYJzaAaZFQMGpJFkD5c3Jt66j1v83wN/m6D/SM9yyx+dN6XTfGAg=="],
-
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
@@ -2090,8 +2088,6 @@
 
     "metro-transform-worker/@babel/types": ["@babel/types@7.27.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q=="],
 
-    "nitro-codegen/react-native-nitro-modules": ["react-native-nitro-modules@0.26.4", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-sCZ0U+FY6JM73HaZYyc4kSRV7JQZXGfbimpYJzaAaZFQMGpJFkD5c3Jt66j1v83wN/m6D/SM9yyx+dN6XTfGAg=="],
-
     "ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "ora/cli-cursor": ["cli-cursor@2.1.0", "", { "dependencies": { "restore-cursor": "^2.0.0" } }, "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw=="],
@@ -2113,8 +2109,6 @@
     "react-native/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
-
-    "react-native-healthkit-example/react-native-nitro-modules": ["react-native-nitro-modules@0.26.4", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-sCZ0U+FY6JM73HaZYyc4kSRV7JQZXGfbimpYJzaAaZFQMGpJFkD5c3Jt66j1v83wN/m6D/SM9yyx+dN6XTfGAg=="],
 
     "react-native-web/@react-native/normalize-colors": ["@react-native/normalize-colors@0.74.89", "", {}, "sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg=="],
 

--- a/packages/react-native-healthkit/ios/CategoryTypeModule.swift
+++ b/packages/react-native-healthkit/ios/CategoryTypeModule.swift
@@ -7,7 +7,7 @@ class CategoryTypeModule: HybridCategoryTypeModuleSpec {
         value: Double,
         startDate: Date,
         endDate: Date,
-        metadata: AnyMapHolder
+        metadata: AnyMap
     ) throws -> Promise<Bool> {
         let type = try initializeCategoryType(identifier.stringValue)
 

--- a/packages/react-native-healthkit/ios/CorrelationTypeModule.swift
+++ b/packages/react-native-healthkit/ios/CorrelationTypeModule.swift
@@ -7,7 +7,7 @@ class CorrelationTypeModule: HybridCorrelationTypeModuleSpec {
         samples: [SampleForSaving],
         start: Date,
         end: Date,
-        metadata: AnyMapHolder
+        metadata: AnyMap
     ) throws -> Promise<Bool> {
         let correlationType = try initializeCorrelationType(typeIdentifier.stringValue)
 

--- a/packages/react-native-healthkit/ios/QuantityTypeModule.swift
+++ b/packages/react-native-healthkit/ios/QuantityTypeModule.swift
@@ -79,7 +79,7 @@ func saveQuantitySampleInternal(
     }
 }
 
-func getAnyMapValue(_ anyMap: AnyMapHolder, key: String) -> Any? {
+func getAnyMapValue(_ anyMap: AnyMap, key: String) -> Any? {
     if anyMap.isBool(key: key) {
         return anyMap.getBoolean(key: key)
     }
@@ -104,7 +104,7 @@ func getAnyMapValue(_ anyMap: AnyMapHolder, key: String) -> Any? {
     return nil
 }
 
-func anyMapToDictionary(_ anyMap: AnyMapHolder) -> [String: Any] {
+func anyMapToDictionary(_ anyMap: AnyMap) -> [String: Any] {
     var dict = [String: Any]()
     anyMap.getAllKeys().forEach { key in
         dict[key] = getAnyMapValue(anyMap, key: key)
@@ -453,7 +453,7 @@ class QuantityTypeModule: HybridQuantityTypeModuleSpec {
         }
     }
 
-    func saveQuantitySample(identifier: QuantityTypeIdentifier, unit: String, value: Double, start: Date, end: Date, metadata: AnyMapHolder) throws -> Promise<Bool> {
+    func saveQuantitySample(identifier: QuantityTypeIdentifier, unit: String, value: Double, start: Date, end: Date, metadata: AnyMap) throws -> Promise<Bool> {
         return saveQuantitySampleInternal(
             typeIdentifier: HKQuantityType(
                 HKQuantityTypeIdentifier(rawValue: identifier.stringValue)

--- a/packages/react-native-healthkit/ios/Serializers.swift
+++ b/packages/react-native-healthkit/ios/Serializers.swift
@@ -207,8 +207,8 @@ func serializeUnknownQuantity(quantity: HKQuantity) -> [String: AnyValue]? {
     return nil
 }
 
-func serializeMetadata(_ metadata: [String: Any]?) -> AnyMapHolder {
-    let serialized = AnyMapHolder()
+func serializeMetadata(_ metadata: [String: Any]?) -> AnyMap {
+    let serialized = AnyMap()
     if let m = metadata {
         for item in m {
             if let bool = item.value as? Bool {

--- a/packages/react-native-healthkit/ios/StateOfMindModule.swift
+++ b/packages/react-native-healthkit/ios/StateOfMindModule.swift
@@ -91,7 +91,7 @@ class StateOfMindModule: HybridStateOfMindModuleSpec {
         valence: Double,
         labels: [StateOfMindLabel],
         associations: [StateOfMindAssociation],
-        metadata: AnyMapHolder?
+        metadata: AnyMap?
     ) throws -> Promise<Bool> {
         if #available(iOS 18, *) {
             return Promise.async {
@@ -119,7 +119,7 @@ class StateOfMindModule: HybridStateOfMindModuleSpec {
                             valence: valence,
                             labels: hkLabels,
                             associations: hkAssociations,
-                            metadata: anyMapToDictionary(metadata ?? AnyMapHolder())
+                            metadata: anyMapToDictionary(metadata ?? AnyMap())
                         )
 
                         store.save(sample) { (success: Bool, error: Error?) in

--- a/packages/react-native-healthkit/ios/WorkoutProxy.swift
+++ b/packages/react-native-healthkit/ios/WorkoutProxy.swift
@@ -328,7 +328,7 @@ class WorkoutProxy: HybridWorkoutProxySpec {
     }
   }
 
-  var metadata: AnyMapHolder? {
+  var metadata: AnyMap? {
     get {
       return serializeMetadata(workout.metadata)
     }

--- a/packages/react-native-healthkit/ios/WorkoutsModule.swift
+++ b/packages/react-native-healthkit/ios/WorkoutsModule.swift
@@ -101,7 +101,7 @@ class WorkoutsModule: HybridWorkoutsModuleSpec {
         startDate: Date,
         endDate: Date,
         totals: WorkoutTotals,
-        metadata: AnyMapHolder
+        metadata: AnyMap
     ) throws -> Promise<String> {
 
         let type = try initializeWorkoutActivityType(UInt(workoutActivityType.rawValue))

--- a/packages/react-native-healthkit/package.json
+++ b/packages/react-native-healthkit/package.json
@@ -90,10 +90,10 @@
   "devDependencies": {
     "@testing-library/react-native": "^13.2.0",
     "@types/react": "~19.0.14",
-    "nitro-codegen": "^0.26.2",
+    "nitro-codegen": "^0.26.4",
     "react": "19.0.0",
     "react-native": "*",
-    "react-native-nitro-modules": "^0.26.2",
+    "react-native-nitro-modules": "^0.26.4",
     "typescript": "~5.8.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- update `react-native-nitro-modules` and `nitro-codegen` to 0.26.4
- use `AnyMap` type introduced by nitro-modules

## Testing
- `bun test packages/react-native-healthkit` *(fails: Unexpected typeof)*

------
https://chatgpt.com/codex/tasks/task_e_68833563ddb4832da79fcd1893edd2ca