### PR TITLE
chore: saveWorkoutSample return workout proxy

### DIFF
--- a/.changeset/tall-times-ask.md
+++ b/.changeset/tall-times-ask.md
@@ -1,0 +1,6 @@
+---
+"@kingstinct/react-native-healthkit": major
+---
+
+chore: saveWorkoutSample return workout proxy
+  

--- a/packages/react-native-healthkit/src/healthkit.ts
+++ b/packages/react-native-healthkit/src/healthkit.ts
@@ -242,7 +242,8 @@ export const queryWorkoutSamplesWithAnchor = UnavailableFnFromModule(
 )
 export const saveWorkoutSample = UnavailableFnFromModule(
   'saveWorkoutSample',
-  Promise.resolve(''),
+  // biome-ignore lint/suspicious/noExplicitAny: it works
+  Promise.resolve(undefined as any as WorkoutProxy),
 )
 export const startWatchApp = UnavailableFnFromModule(
   'startWatchApp',

--- a/packages/react-native-healthkit/src/specs/WorkoutsModule.nitro.ts
+++ b/packages/react-native-healthkit/src/specs/WorkoutsModule.nitro.ts
@@ -18,7 +18,7 @@ export interface WorkoutsModule extends HybridObject<{ ios: 'swift' }> {
     endDate: Date,
     totals: WorkoutTotals,
     metadata: AnyMap,
-  ): Promise<string>
+  ): Promise<WorkoutProxy>
 
   queryWorkoutSamplesWithAnchor(
     options: WorkoutQueryOptionsWithAnchor,


### PR DESCRIPTION
When creating a workout sample, return the workout proxy, so we can further interact with it; for example, to save the workout route.

Closes #199