### PR TITLE
chore: update Xcode beta path in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
         run: bun install --ignore-scripts --frozen-lockfile
 
       ## latest stable
-      - run: sudo xcode-select -s /Applications/Xcode_26_beta.app
+      - run: sudo xcode-select -s /Applications/Xcode_26_beta_5.app
 
       - name: Install iOS 26 simulator runtime
         run: |


### PR DESCRIPTION
## Summary
- fix CI build on macOS by pointing beta job to new Xcode 26 beta 5 path

## Testing
- `bun run lint`
- `bun run test`
- `bun run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a4933a7194832d96c295a8a48f1a80