### PR TITLE
feat: add startDate and endDate to QueryStatisticsResponse

### DIFF
--- a/.changeset/sour-geese-follow.md
+++ b/.changeset/sour-geese-follow.md
@@ -1,0 +1,6 @@
+---
+"@kingstinct/react-native-healthkit": patch
+---
+
+Add startDate and endDate to QueryStatisticsResponse
+  

--- a/packages/react-native-healthkit/ios/QuantityTypeModule.swift
+++ b/packages/react-native-healthkit/ios/QuantityTypeModule.swift
@@ -191,6 +191,9 @@ class QuantityTypeModule: HybridQuantityTypeModuleSpec {
 
                     var response = QueryStatisticsResponse()
 
+                    response.startDate = gottenStats.startDate
+                    response.endDate = gottenStats.endDate
+
                     if let averageQuantity = gottenStats.averageQuantity() {
                         response.averageQuantity = Quantity(
                             unit: unit.unitString,
@@ -322,6 +325,9 @@ class QuantityTypeModule: HybridQuantityTypeModuleSpec {
 
                     statistics.enumerateStatistics(from: enumerateFrom, to: enumerateTo) { stats, _ in
                         var response = QueryStatisticsResponse()
+
+                        response.startDate = stats.startDate
+                        response.endDate = stats.endDate
 
                         if let averageQuantity = stats.averageQuantity() {
                             response.averageQuantity = Quantity(

--- a/packages/react-native-healthkit/src/types/QuantityType.ts
+++ b/packages/react-native-healthkit/src/types/QuantityType.ts
@@ -28,6 +28,8 @@ export interface QueryStatisticsResponse {
   readonly mostRecentQuantity?: Quantity
   readonly mostRecentQuantityDateInterval?: QuantityDateInterval
   readonly duration?: Quantity
+  readonly startDate?: Date
+  readonly endDate?: Date
 }
 
 export interface QuantitySamplesWithAnchorResponse {


### PR DESCRIPTION
Add `startDate` and `endDate` to `QueryStatisticsResponse` so that when `queryStatisticsCollectionForQuantity` is called, we can know the time range to which the object belongs.

## Example

```
const res = await HealthKit.queryStatisticsCollectionForQuantity(
	"HKQuantityTypeIdentifierStepCount",
	["cumulativeSum"],
	startISO,
	{ hour: 1 },
	{
		filter: {
			startDate: start,
			endDate: new Date(),
		},
	},
);
```

### Result
```
  {
    "sumQuantity": {
      "unit": "count",
      "quantity": 885.8011097544891
    },
    "startDate": "2025-08-23T08:00:00.000Z",
    "endDate": "2025-08-23T09:00:00.000Z"
  },
  {
    "sumQuantity": {
      "unit": "count",
      "quantity": 2284.2459891965395
    },
    "startDate": "2025-08-23T09:00:00.000Z",
    "endDate": "2025-08-23T10:00:00.000Z"
  },

```