### PR TITLE
ci: update Xcode beta path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
         run: bun install --ignore-scripts --frozen-lockfile
 
       ## latest stable
-      - run: sudo xcode-select -s /Applications/Xcode_26_beta_5.app
+      - run: sudo xcode-select -s /Applications/Xcode_26.0.app
 
       - name: Install iOS 26 simulator runtime
         run: |


### PR DESCRIPTION
## Summary
- point beta build workflow to Xcode_26.0

## Testing
- `bun run lint`
- `bun test` *(fails: Unexpected typeof in react-native)*

------
https://chatgpt.com/codex/tasks/task_e_68b55cc45ce0832d8be566c762e0235e