### PR TITLE
fix: saveWorkoutSample crash with empty quantities

### DIFF
--- a/.changeset/soft-badgers-fry.md
+++ b/.changeset/soft-badgers-fry.md
@@ -1,0 +1,5 @@
+---
+"@kingstinct/react-native-healthkit": patch
+---
+
+fix: saveWorkoutSample crash with empty quantities

--- a/packages/react-native-healthkit/ios/WorkoutsModule.swift
+++ b/packages/react-native-healthkit/ios/WorkoutsModule.swift
@@ -221,9 +221,11 @@ class WorkoutsModule: HybridWorkoutsModuleSpec {
                     if let error = error {
                         return continuation.resume(throwing: error)
                     }
-                    store.add(initializedSamples, to: workout) { (_, error: Error?) in
-                        if let error = error {
-                            return continuation.resume(throwing: error)
+                    if !initializedSamples.isEmpty {
+                        store.add(initializedSamples, to: workout) { (_, error: Error?) in
+                            if let error = error {
+                                return continuation.resume(throwing: error)
+                            }
                         }
                     }
                     return continuation.resume()


### PR DESCRIPTION
Fix crash when saving workout with empty quantities

```ts
const workout = await saveWorkoutSample(
  WorkoutActivityType.traditionalStrengthTraining,
  [],
  startAt,
  endAt,
  {
    energyBurned,
  },
  {},
);
```