### PR TITLE
feat: add comprehensive mindful session support

### DIFF
--- a/apps/example/app/(tabs)/_layout.tsx
+++ b/apps/example/app/(tabs)/_layout.tsx
@@ -191,6 +191,20 @@ export default function TabLayout() {
           ),
         }}
       />
+
+      <Tabs.Screen
+        name="mindfulSessions"
+        options={{
+          title: 'Mindful',
+          tabBarIcon: ({ color, focused }) => (
+            <IconSymbol
+              size={28}
+              name={focused ? 'brain.head.profile.fill' : 'brain.head.profile'}
+              color={color}
+            />
+          ),
+        }}
+      />
     </Tabs>
   )
 }

--- a/apps/example/app/(tabs)/mindfulSessions.tsx
+++ b/apps/example/app/(tabs)/mindfulSessions.tsx
@@ -1,0 +1,200 @@
+import { Host, List, Section } from '@expo/ui/swift-ui'
+import {
+  getMostRecentMindfulSession,
+  queryMindfulSessions,
+  saveMindfulSession,
+  useMostRecentMindfulSession,
+  useSubscribeToMindfulSessions,
+} from '@kingstinct/react-native-healthkit'
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, Alert, Button, View } from 'react-native'
+import { ListItem, type ListItemProps } from '@/components/SwiftListItem'
+import { ThemedText } from '@/components/ThemedText'
+
+const MindfulSessionsTab = () => {
+  const [sessions, setSessions] = useState<ListItemProps[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+
+  // Use the hook to get the most recent session
+  const lastSession = useMostRecentMindfulSession()
+
+  // Subscribe to new sessions
+  const { sessions: newSessions, errorMessage } =
+    useSubscribeToMindfulSessions()
+
+  // Load recent sessions on mount
+  useEffect(() => {
+    const loadSessions = async () => {
+      try {
+        setIsLoading(true)
+        const recentSessions = await queryMindfulSessions({
+          limit: 20,
+          ascending: false,
+        })
+
+        const formattedSessions = recentSessions.map((session) => {
+          const durationMs =
+            session.endDate.getTime() - session.startDate.getTime()
+          const minutes = Math.floor(durationMs / 1000 / 60)
+          const seconds = Math.floor((durationMs / 1000) % 60)
+
+          return {
+            title: `${minutes}m ${seconds}s`,
+            subtitle: session.startDate.toLocaleString(),
+            id: session.uuid,
+          }
+        })
+
+        setSessions(formattedSessions)
+      } catch (error) {
+        console.error('Error loading mindful sessions:', error)
+        Alert.alert('Error', 'Failed to load mindful sessions')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadSessions()
+  }, [])
+
+  // Reload when new sessions are detected
+  useEffect(() => {
+    if (newSessions && newSessions.length > 0) {
+      const reloadSessions = async () => {
+        const recentSessions = await queryMindfulSessions({
+          limit: 20,
+          ascending: false,
+        })
+
+        const formattedSessions = recentSessions.map((session) => {
+          const durationMs =
+            session.endDate.getTime() - session.startDate.getTime()
+          const minutes = Math.floor(durationMs / 1000 / 60)
+          const seconds = Math.floor((durationMs / 1000) % 60)
+
+          return {
+            title: `${minutes}m ${seconds}s`,
+            subtitle: session.startDate.toLocaleString(),
+            id: session.uuid,
+          }
+        })
+
+        setSessions(formattedSessions)
+      }
+
+      reloadSessions()
+    }
+  }, [newSessions])
+
+  // Show error if subscription fails
+  useEffect(() => {
+    if (errorMessage) {
+      Alert.alert('Subscription Error', errorMessage)
+    }
+  }, [errorMessage])
+
+  const handleAddSession = async () => {
+    try {
+      setIsSaving(true)
+
+      // Create a 10-minute session ending now
+      const endDate = new Date()
+      const startDate = new Date(endDate.getTime() - 10 * 60 * 1000)
+
+      await saveMindfulSession(startDate, endDate, {
+        HKMetadataKeyUserMotionContext: 0, // stationary
+      })
+
+      Alert.alert('Success', '10-minute mindful session saved!')
+
+      // Reload sessions
+      const recentSessions = await queryMindfulSessions({
+        limit: 20,
+        ascending: false,
+      })
+
+      const formattedSessions = recentSessions.map((session) => {
+        const durationMs =
+          session.endDate.getTime() - session.startDate.getTime()
+        const minutes = Math.floor(durationMs / 1000 / 60)
+        const seconds = Math.floor((durationMs / 1000) % 60)
+
+        return {
+          title: `${minutes}m ${seconds}s`,
+          subtitle: session.startDate.toLocaleString(),
+          id: session.uuid,
+        }
+      })
+
+      setSessions(formattedSessions)
+    } catch (error) {
+      console.error('Error saving mindful session:', error)
+      Alert.alert('Error', 'Failed to save mindful session')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const lastSessionInfo = lastSession
+    ? (() => {
+        const durationMs =
+          lastSession.endDate.getTime() - lastSession.startDate.getTime()
+        const minutes = Math.floor(durationMs / 1000 / 60)
+        const seconds = Math.floor((durationMs / 1000) % 60)
+        return `${minutes}m ${seconds}s`
+      })()
+    : 'No sessions'
+
+  return (
+    <Host style={{ flex: 1 }}>
+      <View style={{ padding: 16 }}>
+        <ThemedText style={{ fontSize: 18, fontWeight: 'bold' }}>
+          Most Recent Session: {lastSessionInfo}
+        </ThemedText>
+        {lastSession && (
+          <ThemedText style={{ fontSize: 14, marginTop: 4 }}>
+            {lastSession.startDate.toLocaleString()}
+          </ThemedText>
+        )}
+
+        <View style={{ marginTop: 16 }}>
+          <Button
+            title={isSaving ? 'Saving...' : 'Add 10-minute Session'}
+            onPress={handleAddSession}
+            disabled={isSaving}
+          />
+        </View>
+      </View>
+
+      {isLoading ? (
+        <ActivityIndicator size="large" style={{ marginTop: 20 }} />
+      ) : (
+        <List
+          scrollEnabled
+          listStyle="automatic"
+          onDeleteItem={(item) => alert(`deleted item at index: ${item}`)}
+        >
+          <Section title={`Recent Sessions (${sessions.length})`}>
+            {sessions.length === 0 ? (
+              <ListItem
+                title="No mindful sessions found"
+                subtitle="Add a session to get started"
+              />
+            ) : (
+              sessions.map((session) => (
+                <ListItem
+                  key={session.id}
+                  title={session.title}
+                  subtitle={session.subtitle}
+                />
+              ))
+            )}
+          </Section>
+        </List>
+      )}
+    </Host>
+  )
+}
+
+export default MindfulSessionsTab

--- a/packages/react-native-healthkit/src/healthkit.ios.ts
+++ b/packages/react-native-healthkit/src/healthkit.ios.ts
@@ -2,12 +2,14 @@ import { Platform } from 'react-native'
 import useHealthkitAuthorization from './hooks/useHealthkitAuthorization'
 import { useIsHealthDataAvailable } from './hooks/useIsHealthDataAvailable'
 import useMostRecentCategorySample from './hooks/useMostRecentCategorySample'
+import useMostRecentMindfulSession from './hooks/useMostRecentMindfulSession'
 import useMostRecentQuantitySample from './hooks/useMostRecentQuantitySample'
 import useMostRecentWorkout from './hooks/useMostRecentWorkout'
 import useSources from './hooks/useSources'
 import useStatisticsForQuantity from './hooks/useStatisticsForQuantity'
 import useSubscribeToCategorySamples from './hooks/useSubscribeToCategorySamples'
 import useSubscribeToChanges from './hooks/useSubscribeToChanges'
+import useSubscribeToMindfulSessions from './hooks/useSubscribeToMindfulSessions'
 import useSubscribeToQuantitySamples from './hooks/useSubscribeToQuantitySamples'
 import {
   CategoryTypes,
@@ -23,11 +25,15 @@ import {
 } from './modules'
 import type { QuantityTypeIdentifier } from './types/QuantityTypeIdentifier'
 import getMostRecentCategorySample from './utils/getMostRecentCategorySample'
+import getMostRecentMindfulSession from './utils/getMostRecentMindfulSession'
 import getMostRecentQuantitySample from './utils/getMostRecentQuantitySample'
 import getMostRecentWorkout from './utils/getMostRecentWorkout'
 import getPreferredUnit from './utils/getPreferredUnit'
+import queryMindfulSessions from './utils/queryMindfulSessions'
+import saveMindfulSession from './utils/saveMindfulSession'
 import { subscribeToCategorySamples } from './utils/subscribeToCategorySamples'
 import { subscribeToChanges } from './utils/subscribeToChanges'
+import subscribeToMindfulSessions from './utils/subscribeToMindfulSessions'
 import { subscribeToQuantitySamples } from './utils/subscribeToQuantitySamples'
 
 export * from './types'
@@ -56,21 +62,27 @@ export type AvailableQuantityTypesBeforeIOS17 = Exclude<
 
 export {
   getMostRecentCategorySample,
+  getMostRecentMindfulSession,
   getMostRecentQuantitySample,
   getMostRecentWorkout,
   getPreferredUnit,
+  queryMindfulSessions,
+  saveMindfulSession,
   subscribeToCategorySamples,
   subscribeToChanges,
+  subscribeToMindfulSessions,
   subscribeToQuantitySamples,
   useHealthkitAuthorization,
   useIsHealthDataAvailable,
   useMostRecentCategorySample,
+  useMostRecentMindfulSession,
   useMostRecentQuantitySample,
   useMostRecentWorkout,
   useSources,
   useStatisticsForQuantity,
   useSubscribeToCategorySamples,
   useSubscribeToChanges,
+  useSubscribeToMindfulSessions,
   useSubscribeToQuantitySamples,
 }
 
@@ -217,6 +229,7 @@ export default {
   getFitzpatrickSkinTypeAsync,
   getWheelchairUseAsync,
   getMostRecentCategorySample,
+  getMostRecentMindfulSession,
   getMostRecentQuantitySample,
   getMostRecentWorkout,
   getPreferredUnits,
@@ -233,6 +246,7 @@ export default {
   queryHeartbeatSeriesSamplesWithAnchor,
   queryElectrocardiogramSamples,
   queryElectrocardiogramSamplesWithAnchor,
+  queryMindfulSessions,
   queryQuantitySamples,
   queryQuantitySamplesWithAnchor,
   queryStatisticsForQuantity,
@@ -246,9 +260,11 @@ export default {
   deleteObjects,
   saveCategorySample,
   saveCorrelationSample,
+  saveMindfulSession,
   saveQuantitySample,
   saveWorkoutSample,
   subscribeToChanges,
+  subscribeToMindfulSessions,
   subscribeToQuantitySamples,
   startWatchApp,
   isProtectedDataAvailable,
@@ -264,9 +280,11 @@ export default {
 
   subscribeToCategorySamples,
   useSubscribeToCategorySamples,
+  useSubscribeToMindfulSessions,
 
   // hooks
   useMostRecentCategorySample,
+  useMostRecentMindfulSession,
   useMostRecentQuantitySample,
   useMostRecentWorkout,
   useSubscribeToChanges,

--- a/packages/react-native-healthkit/src/healthkit.ts
+++ b/packages/react-native-healthkit/src/healthkit.ts
@@ -321,6 +321,41 @@ export function getMostRecentCategorySample<T extends CategoryTypeIdentifier>(
   return Promise.resolve(undefined)
 }
 
+export function getMostRecentMindfulSession(): Promise<
+  | CategorySampleTyped<'HKCategoryTypeIdentifierMindfulSession'>
+  | undefined
+> {
+  if (Platform.OS !== 'ios' && !hasWarned) {
+    console.warn(notAvailableError)
+    hasWarned = true
+  }
+  return Promise.resolve(undefined)
+}
+
+export function queryMindfulSessions(
+  _options?: QueryOptionsWithSortOrder,
+): Promise<
+  CategorySampleTyped<'HKCategoryTypeIdentifierMindfulSession'>[]
+> {
+  if (Platform.OS !== 'ios' && !hasWarned) {
+    console.warn(notAvailableError)
+    hasWarned = true
+  }
+  return Promise.resolve([])
+}
+
+export const saveMindfulSession = UnavailableFnFromModule(
+  'saveMindfulSession',
+  Promise.resolve(undefined),
+)
+
+export const subscribeToMindfulSessions = UnavailableFnFromModule(
+  'subscribeToMindfulSessions',
+  {
+    remove: () => false,
+  },
+)
+
 export const getMostRecentQuantitySample = UnavailableFnFromModule(
   'getMostRecentQuantitySample',
   // biome-ignore lint/suspicious/noExplicitAny: it works
@@ -346,6 +381,21 @@ export function useMostRecentCategorySample<T extends CategoryTypeIdentifier>(
   }
   return undefined
 }
+
+export function useMostRecentMindfulSession():
+  | CategorySampleTyped<'HKCategoryTypeIdentifierMindfulSession'>
+  | undefined {
+  if (Platform.OS !== 'ios' && !hasWarned) {
+    console.warn(notAvailableError)
+    hasWarned = true
+  }
+  return undefined
+}
+
+export const useSubscribeToMindfulSessions = UnavailableFnFromModule(
+  'useSubscribeToMindfulSessions',
+  { sessions: [], errorMessage: undefined },
+)
 
 export const useMostRecentQuantitySample = UnavailableFnFromModule(
   'useMostRecentQuantitySample',
@@ -466,6 +516,7 @@ const HealthkitModule = {
   getDateOfBirth,
   getFitzpatrickSkinType,
   getMostRecentCategorySample,
+  getMostRecentMindfulSession,
   getMostRecentQuantitySample,
   getMostRecentWorkout,
   getPreferredUnits,
@@ -481,6 +532,7 @@ const HealthkitModule = {
   queryHeartbeatSeriesSamplesWithAnchor,
   queryElectrocardiogramSamples,
   queryElectrocardiogramSamplesWithAnchor,
+  queryMindfulSessions,
   queryQuantitySamples,
   queryQuantitySamplesWithAnchor,
   queryStatisticsForQuantity,
@@ -494,9 +546,11 @@ const HealthkitModule = {
   deleteObjects,
   saveCategorySample,
   saveCorrelationSample,
+  saveMindfulSession,
   saveQuantitySample,
   saveWorkoutSample,
   subscribeToChanges,
+  subscribeToMindfulSessions,
   startWatchApp,
   isProtectedDataAvailable,
   queryStateOfMindSamples,
@@ -511,16 +565,18 @@ const HealthkitModule = {
   requestMedicationsAuthorization,
 
   subscribeToCategorySamples,
+  useSubscribeToCategorySamples,
+  useSubscribeToMindfulSessions,
   currentAppSource,
 
   // Hooks
   useMostRecentCategorySample,
+  useMostRecentMindfulSession,
   useMostRecentQuantitySample,
   useMostRecentWorkout,
   useSubscribeToChanges,
   useHealthkitAuthorization,
   useIsHealthDataAvailable,
-  useSubscribeToCategorySamples,
   useSources,
   useStatisticsForQuantity,
   getBiologicalSexAsync,

--- a/packages/react-native-healthkit/src/hooks/useMostRecentMindfulSession.ts
+++ b/packages/react-native-healthkit/src/hooks/useMostRecentMindfulSession.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react'
+
+import type { CategorySampleTyped } from '../types/CategoryType'
+import getMostRecentMindfulSession from '../utils/getMostRecentMindfulSession'
+import useSubscribeToChanges from './useSubscribeToChanges'
+
+/**
+ * Hook to get and subscribe to the most recent mindful session
+ * @returns The most recent mindful session or undefined
+ * @example
+ * ```typescript
+ * function MindfulSessionDisplay() {
+ *   const lastSession = useMostRecentMindfulSession()
+ *
+ *   if (!lastSession) {
+ *     return <Text>No mindful sessions recorded</Text>
+ *   }
+ *
+ *   const duration = lastSession.endDate.getTime() - lastSession.startDate.getTime()
+ *   const minutes = Math.floor(duration / 1000 / 60)
+ *
+ *   return (
+ *     <View>
+ *       <Text>Last mindful session: {minutes} minutes</Text>
+ *       <Text>Started: {lastSession.startDate.toLocaleString()}</Text>
+ *     </View>
+ *   )
+ * }
+ * ```
+ */
+export function useMostRecentMindfulSession() {
+  const [session, setSession] =
+    useState<
+      CategorySampleTyped<'HKCategoryTypeIdentifierMindfulSession'>
+    >()
+
+  const updater = useCallback(() => {
+    void getMostRecentMindfulSession().then(setSession)
+  }, [])
+
+  useSubscribeToChanges('HKCategoryTypeIdentifierMindfulSession', updater)
+
+  return session
+}
+
+export default useMostRecentMindfulSession

--- a/packages/react-native-healthkit/src/hooks/useSubscribeToMindfulSessions.ts
+++ b/packages/react-native-healthkit/src/hooks/useSubscribeToMindfulSessions.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+
+import type { CategorySampleTyped } from '../types/CategoryType'
+import subscribeToMindfulSessions from '../utils/subscribeToMindfulSessions'
+
+/**
+ * Hook to subscribe to new mindful sessions
+ * @param after - Date after which to query for changes (defaults to now)
+ * @returns Object containing new sessions and any error message
+ * @example
+ * ```typescript
+ * function MindfulSessionMonitor() {
+ *   const { sessions, errorMessage } = useSubscribeToMindfulSessions()
+ *
+ *   useEffect(() => {
+ *     if (errorMessage) {
+ *       console.error('Error subscribing to mindful sessions:', errorMessage)
+ *     }
+ *
+ *     if (sessions && sessions.length > 0) {
+ *       console.log(`${sessions.length} new session(s) recorded`)
+ *     }
+ *   }, [sessions, errorMessage])
+ *
+ *   return (
+ *     <View>
+ *       {sessions?.map(session => (
+ *         <Text key={session.uuid}>
+ *           {Math.floor((session.endDate.getTime() - session.startDate.getTime()) / 60000)} min
+ *         </Text>
+ *       ))}
+ *     </View>
+ *   )
+ * }
+ * ```
+ */
+export function useSubscribeToMindfulSessions(after = new Date()) {
+  const [sessions, setSessions] = useState<
+    readonly CategorySampleTyped<'HKCategoryTypeIdentifierMindfulSession'>[]
+  >([])
+  const [errorMessage, setErrorMessage] = useState<string>()
+
+  useEffect(() => {
+    const unsubscribe = subscribeToMindfulSessions((args) => {
+      if ('errorMessage' in args) {
+        setErrorMessage(args.errorMessage)
+        return
+      }
+
+      if ('samples' in args) {
+        setSessions(args.samples)
+      }
+    }, after)
+
+    return unsubscribe
+  }, [after])
+
+  return { sessions, errorMessage }
+}
+
+export default useSubscribeToMindfulSessions

--- a/packages/react-native-healthkit/src/utils/getMostRecentMindfulSession.ts
+++ b/packages/react-native-healthkit/src/utils/getMostRecentMindfulSession.ts
@@ -1,0 +1,28 @@
+import { CategoryTypes } from '../modules'
+
+/**
+ * Get the most recent mindful session from HealthKit
+ * @returns Promise that resolves to the most recent mindful session or undefined
+ * @example
+ * ```typescript
+ * const lastSession = await getMostRecentMindfulSession()
+ *
+ * if (lastSession) {
+ *   const duration = lastSession.endDate.getTime() - lastSession.startDate.getTime()
+ *   console.log(`Last session was ${duration / 1000 / 60} minutes`)
+ * }
+ * ```
+ */
+export async function getMostRecentMindfulSession() {
+  const samples = await CategoryTypes.queryCategorySamples(
+    'HKCategoryTypeIdentifierMindfulSession',
+    {
+      limit: 1,
+      ascending: false,
+    },
+  )
+
+  return samples[0]
+}
+
+export default getMostRecentMindfulSession

--- a/packages/react-native-healthkit/src/utils/queryMindfulSessions.ts
+++ b/packages/react-native-healthkit/src/utils/queryMindfulSessions.ts
@@ -1,0 +1,39 @@
+import { CategoryTypes } from '../modules'
+import type { QueryOptionsWithSortOrder } from '../types/QueryOptions'
+
+/**
+ * Query mindful sessions from HealthKit
+ * @param options - Query options including filter, limit, and sort order
+ * @returns Promise that resolves to an array of mindful session samples
+ * @example
+ * ```typescript
+ * // Get the 10 most recent mindful sessions
+ * const sessions = await queryMindfulSessions({
+ *   limit: 10,
+ *   ascending: false,
+ * })
+ *
+ * // Get sessions from the last week
+ * const weekAgo = new Date()
+ * weekAgo.setDate(weekAgo.getDate() - 7)
+ *
+ * const recentSessions = await queryMindfulSessions({
+ *   limit: 0,
+ *   filter: {
+ *     date: {
+ *       startDate: weekAgo,
+ *     },
+ *   },
+ * })
+ * ```
+ */
+export async function queryMindfulSessions(
+  options: QueryOptionsWithSortOrder = { limit: 20, ascending: false },
+) {
+  return CategoryTypes.queryCategorySamples(
+    'HKCategoryTypeIdentifierMindfulSession',
+    options,
+  )
+}
+
+export default queryMindfulSessions

--- a/packages/react-native-healthkit/src/utils/saveMindfulSession.ts
+++ b/packages/react-native-healthkit/src/utils/saveMindfulSession.ts
@@ -1,0 +1,34 @@
+import type { AnyMap } from 'react-native-nitro-modules'
+import { CategoryTypes } from '../modules'
+
+/**
+ * Save a mindful session to HealthKit
+ * @param startDate - The start date and time of the mindful session
+ * @param endDate - The end date and time of the mindful session
+ * @param metadata - Optional metadata for the mindful session
+ * @returns Promise that resolves to the saved mindful session or undefined
+ * @example
+ * ```typescript
+ * const now = new Date()
+ * const tenMinutesAgo = new Date(now.getTime() - 10 * 60 * 1000)
+ *
+ * await saveMindfulSession(tenMinutesAgo, now, {
+ *   HKMetadataKeyUserMotionContext: 0 // stationary
+ * })
+ * ```
+ */
+export async function saveMindfulSession(
+  startDate: Date,
+  endDate: Date,
+  metadata?: AnyMap,
+) {
+  return CategoryTypes.saveCategorySample(
+    'HKCategoryTypeIdentifierMindfulSession',
+    0, // CategoryValueNotApplicable
+    startDate,
+    endDate,
+    metadata,
+  )
+}
+
+export default saveMindfulSession

--- a/packages/react-native-healthkit/src/utils/subscribeToMindfulSessions.ts
+++ b/packages/react-native-healthkit/src/utils/subscribeToMindfulSessions.ts
@@ -1,0 +1,69 @@
+import { CategoryTypes } from '../modules'
+import type { OnCategorySamplesCallback } from '../types/Subscriptions'
+import { subscribeToChanges } from './subscribeToChanges'
+
+/**
+ * Subscribe to changes in mindful sessions
+ * @param callback - Function called when mindful sessions change
+ * @param after - Date after which to query for changes (defaults to now)
+ * @returns Unsubscribe function
+ * @example
+ * ```typescript
+ * const unsubscribe = subscribeToMindfulSessions(({ samples, errorMessage }) => {
+ *   if (errorMessage) {
+ *     console.error('Error:', errorMessage)
+ *     return
+ *   }
+ *
+ *   if (samples && samples.length > 0) {
+ *     console.log(`${samples.length} new mindful session(s) logged`)
+ *     samples.forEach(session => {
+ *       const duration = session.endDate.getTime() - session.startDate.getTime()
+ *       console.log(`Session duration: ${duration / 1000 / 60} minutes`)
+ *     })
+ *   }
+ * })
+ *
+ * // Later, when you want to stop listening:
+ * unsubscribe()
+ * ```
+ */
+export function subscribeToMindfulSessions(
+  callback: (
+    args: OnCategorySamplesCallback<'HKCategoryTypeIdentifierMindfulSession'>,
+  ) => void,
+  after = new Date(),
+) {
+  return subscribeToChanges(
+    'HKCategoryTypeIdentifierMindfulSession',
+    async ({ errorMessage }) => {
+      if (errorMessage) {
+        return callback({
+          typeIdentifier: 'HKCategoryTypeIdentifierMindfulSession',
+          errorMessage,
+        } as OnCategorySamplesCallback<'HKCategoryTypeIdentifierMindfulSession'>)
+      }
+
+      const samplesAfterLast = await CategoryTypes.queryCategorySamples(
+        'HKCategoryTypeIdentifierMindfulSession',
+        {
+          limit: 0,
+          filter: {
+            date: {
+              startDate: after,
+            },
+          },
+        },
+      )
+
+      if (samplesAfterLast.length > 0) {
+        callback({
+          typeIdentifier: 'HKCategoryTypeIdentifierMindfulSession',
+          samples: samplesAfterLast,
+        } as OnCategorySamplesCallback<'HKCategoryTypeIdentifierMindfulSession'>)
+      }
+    },
+  )
+}
+
+export default subscribeToMindfulSessions


### PR DESCRIPTION
Add dedicated helper functions, hooks, and example UI for working with
HealthKit mindful sessions. This provides developers with an easier API
for tracking meditation and mindfulness data.

Changes:
- Add saveMindfulSession() helper for recording mindful sessions
- Add queryMindfulSessions() for retrieving session history
- Add getMostRecentMindfulSession() for latest session
- Add subscribeToMindfulSessions() for real-time updates
- Add useMostRecentMindfulSession() React hook
- Add useSubscribeToMindfulSessions() React hook
- Add example screen in example app with session creation and display
- Update README with mindful session usage examples
- Export all new functions from main healthkit module