### PR TITLE
fix: serializeAnchor uses new NSKeyedArchiver function

### DIFF
--- a/.changeset/fresh-actors-breathe.md
+++ b/.changeset/fresh-actors-breathe.md
@@ -1,0 +1,5 @@
+---
+"@kingstinct/react-native-healthkit": patch
+---
+
+fix: serializeAnchor uses new NSKeyedArchiver function

--- a/packages/react-native-healthkit/ios/Helpers.swift
+++ b/packages/react-native-healthkit/ios/Helpers.swift
@@ -86,14 +86,11 @@ func serializeAnchor(anchor: HKQueryAnchor?) -> String? {
 }
 
 func toBase64(_ data: Any?) -> String? {
-  if let data = data {
-    let data = NSKeyedArchiver.archivedData(withRootObject: data)
-    let encoded = data.base64EncodedString()
-
-    return encoded
+  guard let archivedData = try? NSKeyedArchiver.archivedData(withRootObject: data, requiringSecureCoding: true) else {
+    return nil
   }
 
-  return nil
+  return archivedData.base64EncodedString()
 }
 
 func sampleQueryAsync(


### PR DESCRIPTION
Deprecation Notice: https://developer.apple.com/documentation/foundation/nskeyedarchiver/archiveddata(withrootobject:)

New function: NSKeyedArchiver.archivedData(withRootObject: anchor, requiringSecureCoding: true)