### PR TITLE
Remove --non-interactive flags from build scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Expo Prebuild
         working-directory: apps/example
-        run: bunx expo prebuild --platform ios --non-interactive
+        run: bunx expo prebuild --platform ios
 
       - name: Build iOS project
         working-directory: apps/example/ios

--- a/apps/example/scripts/run-healthkit-contracts.sh
+++ b/apps/example/scripts/run-healthkit-contracts.sh
@@ -123,7 +123,7 @@ rm -f "$METRO_LOG"
 if ! curl -fsS --max-time 2 "http://127.0.0.1:8081/status" >/dev/null 2>&1; then
   (
     cd "$APP_DIR"
-    bun start --clear --non-interactive >"$METRO_LOG" 2>&1
+    CI=1 bun start --clear >"$METRO_LOG" 2>&1
   ) &
   METRO_PID="$!"
 


### PR DESCRIPTION
## Summary
Removes the `--non-interactive` flag from Expo prebuild and Metro bundler commands, replacing it with the `CI=1` environment variable for the Metro bundler to better align with standard CI/CD practices.

## Changes
- **Expo prebuild**: Removed `--non-interactive` flag from the iOS prebuild command in the GitHub Actions workflow
- **Metro bundler**: Replaced `--non-interactive` flag with `CI=1` environment variable in the HealthKit contracts test script

## Details
These changes modernize the build configuration by:
1. Using environment-based signaling (`CI=1`) instead of command-line flags for CI detection in Metro
2. Allowing Expo prebuild to operate with its default behavior in non-interactive environments
3. Following standard conventions where the `CI` environment variable is the canonical way to indicate a continuous integration context

https://claude.ai/code/session_01Kd5nY1iNaeEsUNSF76z1bN