### PR TITLE
feat: add queryActivitySummaries

### DIFF
--- a/.changeset/itchy-pandas-applaud.md
+++ b/.changeset/itchy-pandas-applaud.md
@@ -1,0 +1,5 @@
+---
+"@kingstinct/react-native-healthkit": minor
+---
+
+Add `queryActivitySummaries(startDate, endDate)` exposing `HKActivitySummaryQuery` — per-day activity ring values and goals (move, exercise, stand)

--- a/packages/react-native-healthkit/ios/ActivitySummaryModule.swift
+++ b/packages/react-native-healthkit/ios/ActivitySummaryModule.swift
@@ -1,0 +1,51 @@
+import HealthKit
+import NitroModules
+
+class ActivitySummaryModule: HybridActivitySummaryModuleSpec {
+  func queryActivitySummaries(startDate: Date, endDate: Date) throws -> Promise<[ActivitySummary]> {
+    return Promise.async {
+      let calendar = Calendar.current
+
+      var startComponents = calendar.dateComponents(
+        [.day, .month, .year, .era], from: startDate)
+      var endComponents = calendar.dateComponents(
+        [.day, .month, .year, .era], from: endDate)
+      // HKActivitySummaryQuery requires the calendar to be set on the predicate's
+      // DateComponents — without it the query returns no results.
+      startComponents.calendar = calendar
+      endComponents.calendar = calendar
+
+      let predicate = HKQuery.predicate(
+        forActivitySummariesBetweenStart: startComponents, end: endComponents)
+
+      let summaries: [HKActivitySummary] = try await withCheckedThrowingContinuation {
+        continuation in
+        let query = HKActivitySummaryQuery(predicate: predicate) { _, summaries, error in
+          if let error = error {
+            continuation.resume(throwing: error)
+          } else {
+            continuation.resume(returning: summaries ?? [])
+          }
+        }
+        store.execute(query)
+      }
+
+      return summaries.map { summary in
+        let components = summary.dateComponents(for: calendar)
+        return ActivitySummary(
+          dateYear: Double(components.year ?? 0),
+          dateMonth: Double(components.month ?? 0),
+          dateDay: Double(components.day ?? 0),
+          activeEnergyBurned: summary.activeEnergyBurned.doubleValue(for: .kilocalorie()),
+          activeEnergyBurnedGoal: summary.activeEnergyBurnedGoal.doubleValue(for: .kilocalorie()),
+          appleExerciseTime: summary.appleExerciseTime.doubleValue(for: .minute()),
+          appleExerciseTimeGoal: summary.appleExerciseTimeGoal.doubleValue(for: .minute()),
+          appleStandHours: summary.appleStandHours.doubleValue(for: .count()),
+          appleStandHoursGoal: summary.appleStandHoursGoal.doubleValue(for: .count()),
+          appleMoveTime: summary.appleMoveTime.doubleValue(for: .minute()),
+          appleMoveTimeGoal: summary.appleMoveTimeGoal.doubleValue(for: .minute())
+        )
+      }
+    }
+  }
+}

--- a/packages/react-native-healthkit/nitro.json
+++ b/packages/react-native-healthkit/nitro.json
@@ -38,6 +38,9 @@
     },
     "MedicationModule": {
       "swift": "MedicationModule"
+    },
+    "ActivitySummaryModule": {
+      "swift": "ActivitySummaryModule"
     }
   },
   "ignorePaths": ["**/node_modules"]

--- a/packages/react-native-healthkit/src/healthkit.ios.ts
+++ b/packages/react-native-healthkit/src/healthkit.ios.ts
@@ -10,6 +10,7 @@ import useSubscribeToCategorySamples from './hooks/useSubscribeToCategorySamples
 import useSubscribeToChanges from './hooks/useSubscribeToChanges'
 import useSubscribeToQuantitySamples from './hooks/useSubscribeToQuantitySamples'
 import {
+  ActivitySummaries,
   CategoryTypes,
   Characteristics,
   Core,
@@ -38,6 +39,7 @@ import type {
   MedicationDoseEventTyped,
 } from './types/Medication'
 import type { QuantityTypeIdentifier } from './types/QuantityTypeIdentifier'
+import type { ActivitySummary } from './types/ActivitySummary'
 import type {
   StateOfMindSamplesWithAnchorResponseTyped,
   StateOfMindSampleTyped,
@@ -296,6 +298,19 @@ const MedicationBindings = {
   >
 }
 
+const ActivitySummaryBindings = {
+  queryActivitySummaries: bindRetypedMethod<
+    typeof ActivitySummaries,
+    typeof ActivitySummaries.queryActivitySummaries,
+    Promise<ActivitySummary[]>
+  >(ActivitySummaries, ActivitySummaries.queryActivitySummaries),
+} satisfies {
+  queryActivitySummaries: BoundMethod<
+    typeof ActivitySummaries.queryActivitySummaries,
+    Promise<ActivitySummary[]>
+  >
+}
+
 // Named exports - all functions bound to their respective modules
 export const authorizationStatusFor = Core.authorizationStatusFor.bind(Core)
 export const requestPerObjectReadAuthorization =
@@ -390,6 +405,9 @@ export const queryMedicationEvents = MedicationBindings.queryMedicationEvents
 export const queryMedicationEventsWithAnchor =
   MedicationBindings.queryMedicationEventsWithAnchor
 
+export const queryActivitySummaries =
+  ActivitySummaryBindings.queryActivitySummaries
+
 export const currentAppSource = Core.currentAppSource.bind(Core)
 
 export const getBiologicalSexAsync =
@@ -461,6 +479,7 @@ export default {
   subscribeToQuantitySamples,
   startWatchApp,
   isProtectedDataAvailable,
+  queryActivitySummaries,
   queryStateOfMindSamples,
   queryStateOfMindSamplesWithAnchor,
   saveStateOfMindSample,

--- a/packages/react-native-healthkit/src/healthkit.ts
+++ b/packages/react-native-healthkit/src/healthkit.ts
@@ -390,6 +390,12 @@ export const startWatchApp = UnavailableFnFromModule(
   Promise.resolve(false),
 )
 
+// ActivitySummaryModule functions
+export const queryActivitySummaries = UnavailableFnFromModule(
+  'queryActivitySummaries',
+  Promise.resolve([]),
+)
+
 // StateOfMindModule functions
 export const queryStateOfMindSamples = UnavailableFnFromModule(
   'queryStateOfMindSamples',
@@ -630,6 +636,7 @@ const HealthkitModule = {
   subscribeToChanges,
   startWatchApp,
   isProtectedDataAvailable,
+  queryActivitySummaries,
   queryStateOfMindSamples,
   queryStateOfMindSamplesWithAnchor,
   saveStateOfMindSample,

--- a/packages/react-native-healthkit/src/modules.ts
+++ b/packages/react-native-healthkit/src/modules.ts
@@ -1,4 +1,5 @@
 import { NitroModules } from 'react-native-nitro-modules'
+import type { ActivitySummaryModule } from './specs/ActivitySummaryModule.nitro'
 import type {
   CategoryTypeModule,
   CategoryTypeModuleTyped,
@@ -56,3 +57,8 @@ export const HeartbeatSeries =
 
 export const StateOfMind =
   NitroModules.createHybridObject<StateOfMindModule>('StateOfMindModule')
+
+export const ActivitySummaries =
+  NitroModules.createHybridObject<ActivitySummaryModule>(
+    'ActivitySummaryModule',
+  )

--- a/packages/react-native-healthkit/src/specs/ActivitySummaryModule.nitro.ts
+++ b/packages/react-native-healthkit/src/specs/ActivitySummaryModule.nitro.ts
@@ -1,0 +1,13 @@
+import type { HybridObject } from 'react-native-nitro-modules'
+import type { ActivitySummary } from '../types/ActivitySummary'
+
+export interface ActivitySummaryModule extends HybridObject<{ ios: 'swift' }> {
+  /**
+   * Query HKActivitySummary rollups for the calendar days intersecting
+   * [startDate, endDate] (inclusive, interpreted in the user's current calendar).
+   */
+  queryActivitySummaries(
+    startDate: Date,
+    endDate: Date,
+  ): Promise<ActivitySummary[]>
+}

--- a/packages/react-native-healthkit/src/types/ActivitySummary.ts
+++ b/packages/react-native-healthkit/src/types/ActivitySummary.ts
@@ -1,10 +1,12 @@
 /**
  * One HKActivitySummary — the per-day rollup behind the Apple activity rings.
  *
- * Activity summaries are keyed by calendar day ({@link https://developer.apple.com/documentation/healthkit/hkactivitysummary Apple Docs}),
- * not by timestamp, so the date is exposed as plain calendar components from
- * `HKActivitySummary.dateComponents(for:)` rather than a `Date` — converting to a
- * timestamp would force a timezone assumption onto callers.
+ * Activity summaries are keyed by calendar day, not by timestamp, so the date is
+ * exposed as plain calendar components from `HKActivitySummary.dateComponents(for:)`
+ * rather than a `Date` — converting to a timestamp would force a timezone assumption
+ * onto callers.
+ *
+ * @see {@link https://developer.apple.com/documentation/healthkit/hkactivitysummary Apple Docs }
  */
 export interface ActivitySummary {
   /** Calendar year of the summary day (user's current calendar). */

--- a/packages/react-native-healthkit/src/types/ActivitySummary.ts
+++ b/packages/react-native-healthkit/src/types/ActivitySummary.ts
@@ -1,0 +1,32 @@
+/**
+ * One HKActivitySummary — the per-day rollup behind the Apple activity rings.
+ *
+ * Activity summaries are keyed by calendar day ({@link https://developer.apple.com/documentation/healthkit/hkactivitysummary Apple Docs}),
+ * not by timestamp, so the date is exposed as plain calendar components from
+ * `HKActivitySummary.dateComponents(for:)` rather than a `Date` — converting to a
+ * timestamp would force a timezone assumption onto callers.
+ */
+export interface ActivitySummary {
+  /** Calendar year of the summary day (user's current calendar). */
+  readonly dateYear: number
+  /** Calendar month (1–12). */
+  readonly dateMonth: number
+  /** Calendar day of month (1–31). */
+  readonly dateDay: number
+  /** Move ring — active energy burned (kcal). */
+  readonly activeEnergyBurned: number
+  /** Move ring goal (kcal). */
+  readonly activeEnergyBurnedGoal: number
+  /** Exercise ring — Apple exercise time (minutes). */
+  readonly appleExerciseTime: number
+  /** Exercise ring goal (minutes). */
+  readonly appleExerciseTimeGoal: number
+  /** Stand ring — stand hours (count). */
+  readonly appleStandHours: number
+  /** Stand ring goal (count). */
+  readonly appleStandHoursGoal: number
+  /** Move-time variant (move-minutes mode) — minutes; 0 when the user's move ring tracks energy. */
+  readonly appleMoveTime: number
+  /** Move-time goal (minutes); 0 when unused. */
+  readonly appleMoveTimeGoal: number
+}

--- a/packages/react-native-healthkit/src/types/index.ts
+++ b/packages/react-native-healthkit/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './ActivitySummary'
 export * from './Auth'
 export * from './Background'
 export * from './CategoryType'


### PR DESCRIPTION
## Summary

Adds a minimal `queryActivitySummaries(startDate, endDate)` API exposing `HKActivitySummaryQuery` — the per-day Apple activity-ring rollups (move/exercise/stand values **and goals**), which were previously unreachable from this library even though `ActivitySummaryTypeIdentifier` is already supported for authorization.

Closes #215.

## API

```ts
const summaries = await queryActivitySummaries(startDate, endDate)
// → [{ dateYear, dateMonth, dateDay,
//      activeEnergyBurned, activeEnergyBurnedGoal,        // kcal
//      appleExerciseTime, appleExerciseTimeGoal,          // minutes
//      appleStandHours, appleStandHoursGoal,              // count
//      appleMoveTime, appleMoveTimeGoal }]                // minutes (move-minutes mode; 0 otherwise)
```

Design notes:
- Dates are returned as calendar components (`dateYear/dateMonth/dateDay`) rather than a `Date`, because `HKActivitySummary` is keyed by `DateComponents` — converting to a timestamp would impose a timezone assumption on callers. The query inputs are reduced to day granularity in the user's current calendar, which is inherent to `HKActivitySummaryQuery`.
- The predicate sets `.calendar` on both `DateComponents` (the classic `HKActivitySummaryQuery` gotcha — without it the query silently returns nothing).
- New standalone `ActivitySummaryModule` mirroring the existing per-domain module structure (`StateOfMindModule` was the exemplar): nitro spec + `nitro.json` autolinking registration + Swift impl + `bindRetypedMethod` bindings + `UnavailableFnFromModule` fallback on non-iOS platforms.

## Testing

- `bun codegen`, `bun typecheck`, `bun lint`, `bun run test` all green locally.
- **Honest caveat:** authored on Linux against Apple's documentation and this repo's module patterns — I could not run the example app on a device. I'd appreciate a maintainer validating the query on hardware; happy to iterate on anything (API shape included) in review.
