### PR TITLE
feat: iOS 27 category types (MenopausalState, BleedingAfterMenopause) + generator fix for relocated HKWorkoutActivityType

### DIFF
--- a/.changeset/ios27-menopause-types.md
+++ b/.changeset/ios27-menopause-types.md
@@ -1,0 +1,5 @@
+---
+"@kingstinct/react-native-healthkit": minor
+---
+
+Add iOS 27 category types `HKCategoryTypeIdentifierMenopausalState` and `HKCategoryTypeIdentifierBleedingAfterMenopause`. Fix the schema generator to read `HKWorkoutActivityType` from its relocated header (`HKWorkoutActivityType.h`) on iOS 27 SDKs — where it moved out of `HKWorkout.h` — and add a verify guard so the enum can't silently drop again.

--- a/packages/react-native-healthkit/scripts/generate-healthkit.ts
+++ b/packages/react-native-healthkit/scripts/generate-healthkit.ts
@@ -1049,12 +1049,15 @@ export function buildHealthkitSchemaFromSources(sources: {
   readonly metadataHeader: string
   readonly metadataEnumsHeader: string
   readonly workoutHeader: string
+  readonly workoutActivityTypeHeader: string
 }): HealthkitSchema {
   const enumsByName = new Map<string, EnumSchema>()
   for (const enumSchema of [
     ...parseNsEnums(sources.categoryValuesHeader),
     ...parseNsEnums(sources.metadataEnumsHeader),
-    ...parseNsEnums(sources.workoutHeader).filter(
+    ...parseNsEnums(
+      `${sources.workoutHeader}\n${sources.workoutActivityTypeHeader}`,
+    ).filter(
       (schema) =>
         schema.name === 'WorkoutActivityType' ||
         schema.name === 'WorkoutEventType',

--- a/packages/react-native-healthkit/scripts/healthkit-sdk.ts
+++ b/packages/react-native-healthkit/scripts/healthkit-sdk.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -47,6 +48,7 @@ export interface HealthkitSdkSources {
   readonly metadataHeader: string
   readonly metadataEnumsHeader: string
   readonly workoutHeader: string
+  readonly workoutActivityTypeHeader: string
 }
 
 export interface GeneratedArtifactPaths {
@@ -110,6 +112,20 @@ function readHealthkitHeader(relativePath: string, sdkPath: string): string {
   )
 }
 
+// Some enums (e.g. HKWorkoutActivityType, relocated into its own header in newer
+// SDKs) only exist in certain SDK versions; missing headers read as empty.
+function readOptionalHealthkitHeader(
+  relativePath: string,
+  sdkPath: string,
+): string {
+  const headerPath = join(
+    sdkPath,
+    'System/Library/Frameworks/HealthKit.framework',
+    relativePath,
+  )
+  return existsSync(headerPath) ? readFileSync(headerPath, 'utf8') : ''
+}
+
 function readHealthkitSymbolGraph(sdkPath: string): SymbolGraphDocument {
   const outputDir = mkdtempSync(join(tmpdir(), 'healthkit-symbolgraph-'))
 
@@ -161,6 +177,10 @@ export function loadHealthkitSdkSources(
       sdkPath,
     ),
     workoutHeader: readHealthkitHeader('Headers/HKWorkout.h', sdkPath),
+    workoutActivityTypeHeader: readOptionalHealthkitHeader(
+      'Headers/HKWorkoutActivityType.h',
+      sdkPath,
+    ),
   }
 }
 

--- a/packages/react-native-healthkit/scripts/verify-healthkit-sdk.ts
+++ b/packages/react-native-healthkit/scripts/verify-healthkit-sdk.ts
@@ -45,6 +45,20 @@ function main() {
     'Blood glucose should retain canonical unit mapping',
   )
 
+  // Regression guard: iOS 27 relocated HKWorkoutActivityType into its own header,
+  // so a generator that only reads HKWorkout.h drops the whole enum.
+  const workoutActivityType = schema.enums.find(
+    (schemaEnum) => schemaEnum.name === 'WorkoutActivityType',
+  )
+  assert.ok(
+    workoutActivityType,
+    'WorkoutActivityType enum should be present regardless of which header defines it',
+  )
+  assert.ok(
+    workoutActivityType.members.length > 50,
+    'WorkoutActivityType should retain its full member set, not a stub',
+  )
+
   const workoutBrandName = findMetadataKey(
     schema,
     'HKMetadataKeyWorkoutBrandName',

--- a/packages/react-native-healthkit/src/generated/healthkit-schema.json
+++ b/packages/react-native-healthkit/src/generated/healthkit-schema.json
@@ -156,7 +156,7 @@
       "name": "HKQuantityTypeIdentifierCyclingCadence",
       "ios": "17.0",
       "canonicalUnit": "count/min",
-      "aggregationStyle": "Discrete (Arithmetic)",
+      "aggregationStyle": "Discrete (Temporally Weighted)",
       "writeable": true,
       "legacy": false
     },
@@ -172,7 +172,7 @@
       "name": "HKQuantityTypeIdentifierCyclingPower",
       "ios": "17.0",
       "canonicalUnit": "W",
-      "aggregationStyle": "Discrete (Arithmetic)",
+      "aggregationStyle": "Discrete (Temporally Weighted)",
       "writeable": true,
       "legacy": false
     },
@@ -180,7 +180,7 @@
       "name": "HKQuantityTypeIdentifierCyclingSpeed",
       "ios": "17.0",
       "canonicalUnit": "m/s",
-      "aggregationStyle": "Discrete (Arithmetic)",
+      "aggregationStyle": "Discrete (Temporally Weighted)",
       "writeable": true,
       "legacy": false
     },
@@ -772,7 +772,7 @@
       "name": "HKQuantityTypeIdentifierRestingHeartRate",
       "ios": "11.0",
       "canonicalUnit": "count/min",
-      "aggregationStyle": "Discrete (Arithmetic)",
+      "aggregationStyle": "Discrete (Temporally Weighted)",
       "writeable": true,
       "legacy": false
     },
@@ -924,7 +924,7 @@
       "name": "HKQuantityTypeIdentifierWalkingHeartRateAverage",
       "ios": "11.0",
       "canonicalUnit": "count/min",
-      "aggregationStyle": "Discrete (Arithmetic)",
+      "aggregationStyle": "Discrete (Temporally Weighted)",
       "writeable": false,
       "legacy": false
     },
@@ -1008,6 +1008,13 @@
       "name": "HKCategoryTypeIdentifierBladderIncontinence",
       "ios": "14.0",
       "valueEnum": "HKCategoryValueSeverity",
+      "writeable": true,
+      "legacy": false
+    },
+    {
+      "name": "HKCategoryTypeIdentifierBleedingAfterMenopause",
+      "ios": "27.0",
+      "valueEnum": "HKCategoryValueVaginalBleeding",
       "writeable": true,
       "legacy": false
     },
@@ -1267,6 +1274,13 @@
       "name": "HKCategoryTypeIdentifierMemoryLapse",
       "ios": "14.0",
       "valueEnum": "HKCategoryValueSeverity",
+      "writeable": true,
+      "legacy": false
+    },
+    {
+      "name": "HKCategoryTypeIdentifierMenopausalState",
+      "ios": "27.0",
+      "valueEnum": "HKCategoryValueMenopausalState",
       "writeable": true,
       "legacy": false
     },
@@ -1744,6 +1758,27 @@
           "name": "lowFitness",
           "swiftName": "HKCategoryValueLowCardioFitnessEventLowFitness",
           "rawValue": 1
+        }
+      ]
+    },
+    {
+      "name": "CategoryValueMenopausalState",
+      "ios": "27.0",
+      "members": [
+        {
+          "name": "menopause",
+          "swiftName": "HKCategoryValueMenopausalStateMenopause",
+          "rawValue": 1
+        },
+        {
+          "name": "perimenopause",
+          "swiftName": "HKCategoryValueMenopausalStatePerimenopause",
+          "rawValue": 2
+        },
+        {
+          "name": "none",
+          "swiftName": "HKCategoryValueMenopausalStateNone",
+          "rawValue": 3
         }
       ]
     },
@@ -2805,6 +2840,16 @@
           "name": "underwaterDiving",
           "swiftName": "HKWorkoutActivityTypeUnderwaterDiving",
           "rawValue": 84
+        },
+        {
+          "name": "rest",
+          "swiftName": "HKWorkoutActivityTypeRest",
+          "rawValue": 2998
+        },
+        {
+          "name": "group",
+          "swiftName": "HKWorkoutActivityTypeGroup",
+          "rawValue": 2999
         },
         {
           "name": "other",

--- a/packages/react-native-healthkit/src/generated/healthkit.generated.ts
+++ b/packages/react-native-healthkit/src/generated/healthkit.generated.ts
@@ -153,6 +153,7 @@ export type CategoryTypeIdentifierWriteable =
   | 'HKCategoryTypeIdentifierAppleWalkingSteadinessEvent'
   | 'HKCategoryTypeIdentifierAudioExposureEvent'
   | 'HKCategoryTypeIdentifierBladderIncontinence'
+  | 'HKCategoryTypeIdentifierBleedingAfterMenopause'
   | 'HKCategoryTypeIdentifierBleedingAfterPregnancy'
   | 'HKCategoryTypeIdentifierBleedingDuringPregnancy'
   | 'HKCategoryTypeIdentifierBloating'
@@ -186,6 +187,7 @@ export type CategoryTypeIdentifierWriteable =
   | 'HKCategoryTypeIdentifierLowCardioFitnessEvent'
   | 'HKCategoryTypeIdentifierLowerBackPain'
   | 'HKCategoryTypeIdentifierMemoryLapse'
+  | 'HKCategoryTypeIdentifierMenopausalState'
   | 'HKCategoryTypeIdentifierMenstrualFlow'
   | 'HKCategoryTypeIdentifierMindfulSession'
   | 'HKCategoryTypeIdentifierMoodChanges'
@@ -345,6 +347,7 @@ export const CATEGORY_IDENTIFIER_IOS_AVAILABILITY = {
   HKCategoryTypeIdentifierAppleWalkingSteadinessEvent: '15.0',
   HKCategoryTypeIdentifierAudioExposureEvent: '13.0',
   HKCategoryTypeIdentifierBladderIncontinence: '14.0',
+  HKCategoryTypeIdentifierBleedingAfterMenopause: '27.0',
   HKCategoryTypeIdentifierBleedingAfterPregnancy: '18.0',
   HKCategoryTypeIdentifierBleedingDuringPregnancy: '18.0',
   HKCategoryTypeIdentifierBloating: '13.6',
@@ -382,6 +385,7 @@ export const CATEGORY_IDENTIFIER_IOS_AVAILABILITY = {
   HKCategoryTypeIdentifierLowerBackPain: '13.6',
   HKCategoryTypeIdentifierLowHeartRateEvent: '12.2',
   HKCategoryTypeIdentifierMemoryLapse: '14.0',
+  HKCategoryTypeIdentifierMenopausalState: '27.0',
   HKCategoryTypeIdentifierMenstrualFlow: '9.0',
   HKCategoryTypeIdentifierMindfulSession: '10.0',
   HKCategoryTypeIdentifierMoodChanges: '13.6',
@@ -540,6 +544,8 @@ export const CATEGORY_IDENTIFIER_VALUE_ENUMS = {
     'CategoryValueAppleWalkingSteadinessEvent',
   HKCategoryTypeIdentifierAudioExposureEvent: null,
   HKCategoryTypeIdentifierBladderIncontinence: 'CategoryValueSeverity',
+  HKCategoryTypeIdentifierBleedingAfterMenopause:
+    'CategoryValueVaginalBleeding',
   HKCategoryTypeIdentifierBleedingAfterPregnancy:
     'CategoryValueVaginalBleeding',
   HKCategoryTypeIdentifierBleedingDuringPregnancy:
@@ -583,6 +589,7 @@ export const CATEGORY_IDENTIFIER_VALUE_ENUMS = {
   HKCategoryTypeIdentifierLowerBackPain: 'CategoryValueSeverity',
   HKCategoryTypeIdentifierLowHeartRateEvent: 'CategoryValue',
   HKCategoryTypeIdentifierMemoryLapse: 'CategoryValueSeverity',
+  HKCategoryTypeIdentifierMenopausalState: 'CategoryValueMenopausalState',
   HKCategoryTypeIdentifierMenstrualFlow: 'CategoryValueMenstrualFlow',
   HKCategoryTypeIdentifierMindfulSession: 'CategoryValue',
   HKCategoryTypeIdentifierMoodChanges: 'CategoryValuePresence',
@@ -682,6 +689,11 @@ export enum CategoryValueHeadphoneAudioExposureEvent {
 }
 export enum CategoryValueLowCardioFitnessEvent {
   lowFitness = 1,
+}
+export enum CategoryValueMenopausalState {
+  menopause = 1,
+  perimenopause = 2,
+  none = 3,
 }
 export enum CategoryValueMenstrualFlow {
   unspecified = 1,
@@ -911,6 +923,8 @@ export enum WorkoutActivityType {
   swimBikeRun = 82,
   transition = 83,
   underwaterDiving = 84,
+  rest = 2998,
+  group = 2999,
   other = 3000,
 }
 export enum WorkoutEventType {
@@ -935,6 +949,7 @@ export interface CategoryValueByIdentifierMap {
   readonly HKCategoryTypeIdentifierAppleStandHour: CategoryValueAppleStandHour
   readonly HKCategoryTypeIdentifierAppleWalkingSteadinessEvent: CategoryValueAppleWalkingSteadinessEvent
   readonly HKCategoryTypeIdentifierBladderIncontinence: CategoryValueSeverity
+  readonly HKCategoryTypeIdentifierBleedingAfterMenopause: CategoryValueVaginalBleeding
   readonly HKCategoryTypeIdentifierBleedingAfterPregnancy: CategoryValueVaginalBleeding
   readonly HKCategoryTypeIdentifierBleedingDuringPregnancy: CategoryValueVaginalBleeding
   readonly HKCategoryTypeIdentifierBloating: CategoryValueSeverity
@@ -972,6 +987,7 @@ export interface CategoryValueByIdentifierMap {
   readonly HKCategoryTypeIdentifierLowerBackPain: CategoryValueSeverity
   readonly HKCategoryTypeIdentifierLowHeartRateEvent: CategoryValue
   readonly HKCategoryTypeIdentifierMemoryLapse: CategoryValueSeverity
+  readonly HKCategoryTypeIdentifierMenopausalState: CategoryValueMenopausalState
   readonly HKCategoryTypeIdentifierMenstrualFlow: CategoryValueMenstrualFlow
   readonly HKCategoryTypeIdentifierMindfulSession: CategoryValue
   readonly HKCategoryTypeIdentifierMoodChanges: CategoryValuePresence


### PR DESCRIPTION
## What

iOS 27 adds two reproductive-health category types — `HKCategoryTypeIdentifierMenopausalState` and `HKCategoryTypeIdentifierBleedingAfterMenopause`. This regenerates the schema against the iOS 27 SDK to include them.

Regenerating against iOS 27 also surfaced a generator gap: **iOS 27 relocated `HKWorkoutActivityType` out of `HKWorkout.h` into its own `HKWorkoutActivityType.h`**, and the generator only read `HKWorkout.h` — so a regen on the iOS 27 SDK silently dropped the entire `WorkoutActivityType` enum. Fixed the generator to read the relocated header, with a fallback to `HKWorkout.h` on older SDKs.

## Changes

- **Generator** (`scripts/healthkit-sdk.ts`, `scripts/generate-healthkit.ts`): also read `Headers/HKWorkoutActivityType.h` when present (optional read; older SDKs keep the enum in `HKWorkout.h`). Keeps `WorkoutActivityType` from being dropped when regenerating on iOS 27.
- **Regression guard** (`scripts/verify-healthkit-sdk.ts`): assert `WorkoutActivityType` is present with its full member set — mirrors the `BloodKetones` guard added in #354, so this drop can't silently regress on a future SDK bump.
- **Generated** (`src/generated/healthkit.generated.ts`, `healthkit-schema.json`): regenerated against the iOS 27 SDK — adds the two category identifiers (availability `27.0`), the `CategoryValueMenopausalState` enum (`menopause=1`, `perimenopause=2`, `none=3`), and value-enum associations (`MenopausalState → CategoryValueMenopausalState`; `BleedingAfterMenopause → CategoryValueVaginalBleeding`, the shared iOS 18 enum).

## Verification

- Regenerated against the Xcode 27 / iOS 27 SDK with the matching toolchain.
- `bun typecheck && bun lint && bun test` pass.
- Enum ints checked against the SDK header `HKCategoryValues.h` (`HKCategoryValueMenopausalState`: `Menopause = 1 / Perimenopause = 2 / None = 3`).

## Related

- #354 hardens the generator against a different drop (`HKQuantityTypeIdentifierBloodKetones`, via symbol-graph omission). This is the same class of issue — a header-defined type missing from generated output — for `WorkoutActivityType` (via header relocation). The two are complementary and touch overlapping files (`scripts/generate-healthkit.ts`, the generated artifacts), so whichever merges second will need a trivial rebase.
