### PR TITLE
feat: serialize sub-activity activityType on WorkoutActivity

### DIFF
--- a/.changeset/serialize-workout-activity-type.md
+++ b/.changeset/serialize-workout-activity-type.md
@@ -1,0 +1,5 @@
+---
+'@kingstinct/react-native-healthkit': minor
+---
+
+Serialize each workout sub-activity's `activityType` (the raw `HKWorkoutActivityType` from its `workoutConfiguration`) on `WorkoutActivity`, alongside `startDate`/`endDate`/`uuid`/`duration`. This lets consumers type the legs of multisport (`.swimBikeRun`) workouts — e.g. splitting a triathlon into its swim/bike/run legs — which the bridge previously didn't carry.

--- a/packages/react-native-healthkit/ios/WorkoutProxy.swift
+++ b/packages/react-native-healthkit/ios/WorkoutProxy.swift
@@ -374,7 +374,10 @@ class WorkoutProxy: HybridWorkoutProxySpec {
           startDate: activity.startDate,
           endDate: activity.endDate ?? activity.startDate,
           uuid: activity.uuid.uuidString,
-          duration: activity.duration
+          duration: activity.duration,
+          activityType: WorkoutActivityType.init(
+            rawValue: Int32(activity.workoutConfiguration.activityType.rawValue)
+          ) ?? WorkoutActivityType.other
         )
       }
     }

--- a/packages/react-native-healthkit/ios/WorkoutProxy.swift
+++ b/packages/react-native-healthkit/ios/WorkoutProxy.swift
@@ -370,14 +370,23 @@ class WorkoutProxy: HybridWorkoutProxySpec {
       let hkActivities = workout.workoutActivities
 
       return hkActivities.map { activity in
+        let rawActivityType = activity.workoutConfiguration.activityType.rawValue
+        let activityType = Int32(exactly: rawActivityType).flatMap {
+          WorkoutActivityType.init(rawValue: $0)
+        }
+
+        if activityType == nil {
+          warnWithPrefix(
+            "Unknown workoutActivityType with rawValue: \(rawActivityType), falling back to 'other'"
+          )
+        }
+
         return WorkoutActivity(
           startDate: activity.startDate,
           endDate: activity.endDate ?? activity.startDate,
           uuid: activity.uuid.uuidString,
           duration: activity.duration,
-          activityType: WorkoutActivityType.init(
-            rawValue: Int32(activity.workoutConfiguration.activityType.rawValue)
-          ) ?? WorkoutActivityType.other
+          activityType: activityType ?? WorkoutActivityType.other
         )
       }
     }

--- a/packages/react-native-healthkit/src/types/Workouts.ts
+++ b/packages/react-native-healthkit/src/types/Workouts.ts
@@ -36,6 +36,7 @@ export interface WorkoutActivity {
   readonly endDate: Date
   readonly uuid: string
   readonly duration: number
+  readonly activityType: WorkoutActivityType
 }
 
 export interface WorkoutRoute {


### PR DESCRIPTION
## What

`WorkoutProxy.activities` currently serializes each `HKWorkoutActivity` as only `{ startDate, endDate, uuid, duration }` — the sub-activity's `activityType` is dropped at the bridge (`ios/WorkoutProxy.swift`). This PR adds it:

- `WorkoutActivity` gains `readonly activityType: WorkoutActivityType` (`src/types/Workouts.ts`)
- the serializer reads it from `activity.workoutConfiguration.activityType.rawValue`, with the same `?? .other` fallback idiom the parent `workoutActivityType` getter uses

One field, additive; `nitrogen/generated` is gitignored here so the diff is the two source files plus a changeset (minor).

## Why

Without it, multisport (`.swimBikeRun`) workouts are opaque: consumers can see a triathlon has N sub-activities with time windows, but not which leg is the swim, the bike, or the run — `duration`/`uuid` alone can't type a leg, and ordering heuristics break for duathlons (run–bike–run). With the field, each leg can be typed directly off `workoutConfiguration`, transitions (`.transition`) can be filtered by raw value, and per-leg stats can be assembled from sample queries over each leg's window.

## Verification

- `bun codegen` regenerates the nitrogen output cleanly for the new field (standard enum-field codegen, same shape as `WorkoutConfiguration.activityType`); `bun typecheck`, `bun lint`, and `bun run test` all pass on this branch.
- Verified in a consuming app (Expo SDK 57 / RN 0.82, new architecture): we ship this exact change against `14.0.2` via `patch-package` (TS interface + shipped d.ts + regenerated `WorkoutActivity.hpp`/`WorkoutActivity.swift` + the `WorkoutProxy.swift` serializer). The app's typecheck and full Jest suite are green, including tests that consume the typed legs end-to-end (triathlon → per-leg typing by field, transition filtering by raw value, duathlon order-independence); `pod install` consumes the patched pod source. We'd love to drop our patch in favor of an upstream release.

## Notes

- HR/stat queries and everything else are untouched; the field is additive so existing consumers are unaffected.
- `WorkoutActivityType.other` fallback mirrors the existing parent-workout getter rather than force-unwrapping.
