### PR TITLE
Wire background-delivered HealthKit updates through to JS

### DIFF
--- a/.changeset/some-rules-grab.md
+++ b/.changeset/some-rules-grab.md
@@ -1,0 +1,5 @@
+---
+"@kingstinct/react-native-healthkit": patch
+---
+
+Wire background-delivered HealthKit updates through to JS

--- a/packages/react-native-healthkit/ios/BackgroundDeliveryManager.swift
+++ b/packages/react-native-healthkit/ios/BackgroundDeliveryManager.swift
@@ -1,5 +1,8 @@
 import Foundation
 import HealthKit
+import os.log
+
+private let bgLog = OSLog(subsystem: "com.kingstinct.healthkit", category: "BackgroundDelivery")
 
 /// Manages HealthKit background delivery by registering observer queries at app launch,
 /// before the JS bridge is available. This is required by Apple — observer queries must
@@ -20,6 +23,11 @@ import HealthKit
   private var observerQueries: [String: HKObserverQuery] = [:]
   private var pendingEvents: [(typeIdentifier: String, errorMessage: String?)] = []
   private var jsCallback: ((String, String?) -> Void)?
+  // Per-type callbacks, checked before the global `jsCallback` above. Lets
+  // CoreModule.subscribeToObserverQuery route a JS subscription for a
+  // background-configured type through this manager's already-running
+  // HKObserverQuery instead of registering a second, independent one.
+  private var typeCallbacks: [String: (String, String?) -> Void] = [:]
   private var isSetUp = false
 
   static let typesKey = "com.kingstinct.healthkit.backgroundTypes"
@@ -85,6 +93,37 @@ import HealthKit
     }
   }
 
+  /// Subscribe a JS callback for a specific type. Any events for this type
+  /// that arrived before JS subscribed (e.g. from a background wake, queued
+  /// in `pendingEvents` above) are flushed immediately.
+  func setCallback(typeIdentifier: String, callback: @escaping (String, String?) -> Void) {
+    queue.sync(flags: .barrier) {
+      self.typeCallbacks[typeIdentifier] = callback
+      let matching = self.pendingEvents.filter { $0.typeIdentifier == typeIdentifier }
+      self.pendingEvents.removeAll { $0.typeIdentifier == typeIdentifier }
+      for event in matching {
+        callback(typeIdentifier, event.errorMessage)
+      }
+    }
+  }
+
+  /// Remove the per-type JS callback (e.g., on unsubscribe).
+  func removeCallback(typeIdentifier: String) {
+    queue.sync(flags: .barrier) {
+      self.typeCallbacks.removeValue(forKey: typeIdentifier)
+    }
+  }
+
+  /// True if `typeIdentifier` has a native HKObserverQuery registered by
+  /// `registerObservers` — i.e. background delivery is configured for it.
+  /// CoreModule.subscribeToObserverQuery checks this before deciding whether
+  /// to reuse this manager's observer or register its own.
+  func isBackgroundConfigured(typeIdentifier: String) -> Bool {
+    return queue.sync {
+      self.observerQueries[typeIdentifier] != nil
+    }
+  }
+
   /// Stop all observer queries and clear state.
   func tearDown() {
     queue.sync(flags: .barrier) {
@@ -92,6 +131,7 @@ import HealthKit
         self.healthStore.stop(query)
       }
       self.observerQueries = [:]
+      self.typeCallbacks = [:]
       self.isSetUp = false
     }
   }
@@ -121,6 +161,11 @@ import HealthKit
         sampleType: sampleType,
         predicate: nil
       ) { [weak self] (_: HKObserverQuery, completionHandler: @escaping HKObserverQueryCompletionHandler, error: Error?) in
+        // handleObserverCallback opens a beginBackgroundTask() window as its
+        // first, synchronous action, before this returns to call
+        // completionHandler() — otherwise iOS is free to suspend the process
+        // the moment HealthKit's own completion handler fires, possibly
+        // before Hermes has finished booting to run the JS callback.
         self?.handleObserverCallback(
           typeIdentifier: typeIdentifier,
           error: error
@@ -147,17 +192,53 @@ import HealthKit
 
   private func handleObserverCallback(typeIdentifier: String, error: Error?) {
     let errorMessage = error?.localizedDescription
+    os_log("observer fired: %{public}@", log: bgLog, type: .info, typeIdentifier)
+
+    // Ask iOS for real execution time before doing anything else, so the
+    // process survives long enough for Hermes to boot and the JS callback to
+    // run — see the comment at this query's registration above.
+    var backgroundTaskId = UIBackgroundTaskIdentifier.invalid
+    let endTask: () -> Void = { [weak self] in
+      self?.queue.sync(flags: .barrier) {
+        guard backgroundTaskId != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(backgroundTaskId)
+        backgroundTaskId = .invalid
+      }
+    }
+    backgroundTaskId = UIApplication.shared.beginBackgroundTask(withName: "healthkit-observer-\(typeIdentifier)") {
+      os_log("background task expired: %{public}@", log: bgLog, type: .info, typeIdentifier)
+      endTask()
+    }
+    os_log("background task started: %{public}@", log: bgLog, type: .info, typeIdentifier)
 
     queue.sync(flags: .barrier) {
-      if let callback = self.jsCallback {
+      if let callback = self.typeCallbacks[typeIdentifier] {
+        DispatchQueue.main.async {
+          os_log("dispatching to per-type JS callback: %{public}@", log: bgLog, type: .info, typeIdentifier)
+          callback(typeIdentifier, errorMessage)
+        }
+      } else if let callback = self.jsCallback {
         // JS is connected — dispatch to main thread for JSI safety
         DispatchQueue.main.async {
+          os_log("dispatching to global JS callback: %{public}@", log: bgLog, type: .info, typeIdentifier)
           callback(typeIdentifier, errorMessage)
         }
       } else {
         // JS not ready yet — queue the event for later
+        os_log("no JS callback yet, queuing: %{public}@", log: bgLog, type: .info, typeIdentifier)
         self.pendingEvents.append((typeIdentifier: typeIdentifier, errorMessage: errorMessage))
       }
+    }
+
+    // Hold the task open for a fixed, generous window rather than trying to
+    // ack precisely when JS finishes — Hermes boot plus the JS callback's own
+    // async work (HealthKit reads + Supabase upsert) is unpredictable, and a
+    // completion-ack channel back from JS isn't worth building on the first
+    // pass for a personal-use app. First place to revisit if verification
+    // shows this window is too tight.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 25) {
+      os_log("background task window elapsed: %{public}@", log: bgLog, type: .info, typeIdentifier)
+      endTask()
     }
   }
 

--- a/packages/react-native-healthkit/ios/CoreModule.swift
+++ b/packages/react-native-healthkit/ios/CoreModule.swift
@@ -349,6 +349,10 @@ class CoreModule: HybridCoreModuleSpec {
   }
 
   var _runningQueries: [String: HKQuery] = [:]
+  // queryId -> typeIdentifier for subscriptions routed through
+  // BackgroundDeliveryManager instead of getting their own HKObserverQuery
+  // (see subscribeToObserverQuery below).
+  var _backgroundRoutedQueries: [String: String] = [:]
 
   func deleteObjects(objectTypeIdentifier: SampleTypeIdentifierWriteable, filter: FilterForSamples)
     -> Promise<Double> {
@@ -377,6 +381,25 @@ class CoreModule: HybridCoreModuleSpec {
     typeIdentifier: SampleTypeIdentifier,
     callback: @escaping (OnChangeCallbackArgs) -> Void
   ) throws -> String {
+    let typeIdString = typeIdentifier.stringValue
+
+    if BackgroundDeliveryManager.shared.isBackgroundConfigured(typeIdentifier: typeIdString) {
+      // BackgroundDeliveryManager already has an HKObserverQuery running for
+      // this type (registered at launch, survives termination) — route
+      // through it instead of registering a second, independent observer for
+      // the same type.
+      let queryId = UUID().uuidString
+      BackgroundDeliveryManager.shared.setCallback(typeIdentifier: typeIdString) {
+        (_, errorMessage) in
+        DispatchQueue.main.async {
+          callback(
+            OnChangeCallbackArgs(typeIdentifier: typeIdentifier, errorMessage: errorMessage))
+        }
+      }
+      self._backgroundRoutedQueries[queryId] = typeIdString
+      return queryId
+    }
+
     let sampleType = try sampleTypeFrom(sampleTypeIdentifier: typeIdentifier)
 
     let predicate = HKQuery.predicateForSamples(
@@ -411,6 +434,13 @@ class CoreModule: HybridCoreModuleSpec {
   }
 
   func unsubscribeQuery(queryId: String) throws -> Bool {
+    if let typeIdString = self._backgroundRoutedQueries[queryId] {
+      BackgroundDeliveryManager.shared.removeCallback(typeIdentifier: typeIdString)
+      self._backgroundRoutedQueries.removeValue(forKey: queryId)
+
+      return true
+    }
+
     guard let query = self._runningQueries[queryId] else {
       warnWithPrefix("unsubscribeQuery: Query with id \(queryId) not found")
 


### PR DESCRIPTION
## Summary

`BackgroundDeliveryManager`'s `HKObserverQuery` correctly survives app termination and wakes the process (registered in `didFinishLaunchingWithOptions` per Apple's recommendations, see #51), but nothing ever connected its callback to a JS-facing subscription:

- Events either dispatched to a global `jsCallback` that nothing in the library ever registered, or queued into `pendingEvents` that nothing ever drained.
- Separately, `CoreModule.subscribeToObserverQuery` always registered its own independent `HKObserverQuery` for a type, so even a caller that *did* want to listen for a background-configured type ended up with a second, disconnected observer.
- The observer's completion handler was also signaled before asking iOS for any extended execution time, so even a listening JS callback could get suspended before the JS runtime finished booting on a cold, background-triggered launch.

Net effect: the background-delivery machinery wakes the process and detects the data change, then discards that information — functionally equivalent to not having it. This is the gap #51 → #341 (merged with its "kill app, write data, verify wakes and delivers" test-plan item left unchecked) → #343 (closed) → #344 (open, where the discussion pivots to a native-only, no-JS approach) has been circling.

## Changes

- `BackgroundDeliveryManager`: add a per-type callback API (`setCallback`/`removeCallback`/`isBackgroundConfigured`) alongside the existing global one, so a specific type can be subscribed to without touching unrelated types' behavior. Wrap the observer dispatch in `beginBackgroundTask`/`endBackgroundTask`, opened *before* the completion handler fires, for a real execution window.
- `CoreModule.subscribeToObserverQuery`: when a type is already background-configured, route through `BackgroundDeliveryManager`'s per-type API instead of registering a second, independent `HKObserverQuery` for the same type. `unsubscribeQuery` mirrors this for cleanup. Types that aren't background-configured are unaffected — this only changes behavior for types that already opted into background delivery.

This is intentionally scoped to wiring the existing plumbing together rather than the native-only rewrite discussed in #344 — it reuses all the existing JS-side sync logic in consuming apps without duplicating business logic into Swift.

## Test plan

Verified on a real device (iOS, Release build, no debugger attached — a debugger changes iOS's suspend/resume behavior):

- [x] Force-quit a host app with background delivery configured for a type
- [x] Wrote a sample for that type from a different source (Apple Health app directly, not the host app)
- [x] Confirmed via device console logs (`os_log` breadcrumbs + Apple's own HealthKit/RunningBoard logs) that: the observer fired, a named background task opened, and the JS callback ran and completed a sync — all while the host app was fully terminated
- [x] Regression-checked the foreground path (open the app, confirm immediate sync still fires and live updates still work) since this touches `subscribeToObserverQuery`'s shared implementation

One clean trial confirmed the mechanism works end-to-end. I haven't yet run a larger multi-trial success-rate test across varied device states (charging/locked/network) — happy to gather that data if useful for review.