### PR TITLE
fix(plugin): app.plugin.js missing AppDelegate injection; regex misses multi-line Swift signatures

### DIFF
--- a/.changeset/healthkit-appdelegate-plugin-fix.md
+++ b/.changeset/healthkit-appdelegate-plugin-fix.md
@@ -1,0 +1,16 @@
+---
+'@kingstinct/react-native-healthkit': patch
+---
+
+Fix the Expo config plugin's AppDelegate injection for background delivery:
+
+- `app.plugin.js` (the compiled plugin `package.json` actually exposes) was out
+  of sync with `app.plugin.ts` and never contained `withAppDelegatePlugin`, so
+  `BackgroundDeliveryManager.shared.setupBackgroundObservers()` was never added
+  to `didFinishLaunchingWithOptions` — background delivery silently stopped
+  surviving app termination.
+- The injection regex only matched a single-line Swift method signature; Expo
+  SDK 53+ templates spread `didFinishLaunchingWithOptions` over multiple lines,
+  so even the TS plugin missed it. The pattern now spans newlines.
+- If the method still can't be found, the plugin now emits a
+  `WarningAggregator` iOS warning instead of silently doing nothing.

--- a/packages/react-native-healthkit/app.plugin.js
+++ b/packages/react-native-healthkit/app.plugin.js
@@ -1,8 +1,10 @@
 const {
   withPlugins,
   createRunOncePlugin,
+  withAppDelegate,
   withEntitlementsPlist,
   withInfoPlist,
+  WarningAggregator,
 } = require('@expo/config-plugins')
 
 /**
@@ -80,12 +82,71 @@ const withInfoPlistPlugin = (
 const pkg = require('./package.json')
 
 /**
+ * @type {ConfigPlugin<{background: boolean}>}
+ */
+const withAppDelegatePlugin = (
+  config,
+  /**
+   * @type {{background: boolean} | undefined}
+   * */
+  props,
+) => {
+  if (props?.background === false) {
+    return config
+  }
+
+  return withAppDelegate(config, (configDelegate) => {
+    const contents = configDelegate.modResults.contents
+
+    // Add import for HealthKit if not already present
+    if (!contents.includes('import HealthKit')) {
+      configDelegate.modResults.contents =
+        configDelegate.modResults.contents.replace(
+          /^(import .+\n)/m,
+          '$1import HealthKit\n',
+        )
+    }
+
+    // Insert BackgroundDeliveryManager setup into didFinishLaunchingWithOptions
+    const setupCall =
+      '    BackgroundDeliveryManager.shared.setupBackgroundObservers()\n'
+
+    if (
+      !configDelegate.modResults.contents.includes('BackgroundDeliveryManager')
+    ) {
+      // Match the opening of didFinishLaunchingWithOptions and insert after the
+      // opening brace. Expo SDK 53+ templates spread the Swift signature over
+      // multiple lines, so the pattern must span newlines.
+      const didFinishLaunching =
+        /(func application\s*\([\s\S]*?didFinishLaunchingWithOptions[\s\S]*?\)\s*->\s*Bool\s*\{\n)/
+      if (didFinishLaunching.test(configDelegate.modResults.contents)) {
+        configDelegate.modResults.contents =
+          configDelegate.modResults.contents.replace(
+            didFinishLaunching,
+            `$1${setupCall}`,
+          )
+      } else {
+        // Background delivery silently never survives app termination without
+        // this call, so an injection miss must be loud rather than invisible.
+        WarningAggregator.addWarningIOS(
+          pkg.name,
+          'Could not find didFinishLaunchingWithOptions in AppDelegate — HealthKit background delivery will not be registered on cold launch. Add BackgroundDeliveryManager.shared.setupBackgroundObservers() manually.',
+        )
+      }
+    }
+
+    return configDelegate
+  })
+}
+
+/**
  * @type {ConfigPlugin<AppPluginConfig>}
  */
 const healthkitAppPlugin = (config, props) =>
   withPlugins(config, [
     [withEntitlementsPlugin, props],
     [withInfoPlistPlugin, props],
+    [withAppDelegatePlugin, props],
   ])
 
 /**

--- a/packages/react-native-healthkit/app.plugin.ts
+++ b/packages/react-native-healthkit/app.plugin.ts
@@ -1,6 +1,7 @@
 import {
   type ConfigPlugin,
   createRunOncePlugin,
+  WarningAggregator,
   withAppDelegate,
   withEntitlementsPlist,
   withInfoPlist,
@@ -90,12 +91,25 @@ const withAppDelegatePlugin: ConfigPlugin<{
     if (
       !configDelegate.modResults.contents.includes('BackgroundDeliveryManager')
     ) {
-      // Match the opening of didFinishLaunchingWithOptions and insert after the opening brace
-      configDelegate.modResults.contents =
-        configDelegate.modResults.contents.replace(
-          /(func application\(.+didFinishLaunchingWithOptions.+\{)\n/,
-          `$1\n${setupCall}`,
+      // Match the opening of didFinishLaunchingWithOptions and insert after the
+      // opening brace. Expo SDK 53+ templates spread the Swift signature over
+      // multiple lines, so the pattern must span newlines.
+      const didFinishLaunching =
+        /(func application\s*\([\s\S]*?didFinishLaunchingWithOptions[\s\S]*?\)\s*->\s*Bool\s*\{\n)/
+      if (didFinishLaunching.test(configDelegate.modResults.contents)) {
+        configDelegate.modResults.contents =
+          configDelegate.modResults.contents.replace(
+            didFinishLaunching,
+            `$1${setupCall}`,
+          )
+      } else {
+        // Background delivery silently never survives app termination without
+        // this call, so an injection miss must be loud rather than invisible.
+        WarningAggregator.addWarningIOS(
+          pkg.name,
+          'Could not find didFinishLaunchingWithOptions in AppDelegate — HealthKit background delivery will not be registered on cold launch. Add BackgroundDeliveryManager.shared.setupBackgroundObservers() manually.',
         )
+      }
     }
 
     return configDelegate


### PR DESCRIPTION
## Problem

Two compounding bugs mean the Expo config plugin never wires up cold-launch background delivery, even with `background: true`:

1. **`app.plugin.js` is out of sync with `app.plugin.ts`.** `package.json` exposes the compiled `app.plugin.js`, which predates `withAppDelegatePlugin` — it only carries the entitlements + Info.plist mods. So `BackgroundDeliveryManager.shared.setupBackgroundObservers()` is never injected into `didFinishLaunchingWithOptions`, and observer queries registered via `configureBackgroundTypes` don't survive app termination (the doc comment on `configureBackgroundTypes` promises they do).

2. **The injection regex assumes a single-line Swift signature.** `app.plugin.ts` matches `/(func application\(.+didFinishLaunchingWithOptions.+\{)\n/`, but Expo SDK 53+ templates generate:

   ```swift
   public override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
   ```

   so even the TS source would silently skip the injection on current Expo projects. (`String.replace` with no match is a no-op, which is how both bugs stayed invisible.)

## Fix

- Sync `app.plugin.js` with `app.plugin.ts` (adds `withAppDelegatePlugin`).
- Make the `didFinishLaunchingWithOptions` pattern span newlines in both files.
- When the method still can't be found (e.g. an Objective-C AppDelegate), emit a `WarningAggregator.addWarningIOS` warning telling the developer to add the call manually, instead of doing nothing silently.
- Changeset included (patch).

## Verification

Ran `npx expo prebuild -p ios` on an Expo 56 (RN 0.85, Swift AppDelegate) app with this patched `app.plugin.js` and `background: true`:

```swift
import HealthKit           // ← injected
...
  ) -> Bool {
    BackgroundDeliveryManager.shared.setupBackgroundObservers()   // ← injected
```

and both `com.apple.developer.healthkit` + `com.apple.developer.healthkit.background-delivery` land in the generated `.entitlements`. Biome format is clean on both files.

## Note for maintainers

`app.plugin.js` drifting from `app.plugin.ts` is what shipped this bug — none of the `build`/`check:generated` scripts cover it. You may want to either compile it from the TS source in `prepublishOnly` or add a drift check; happy to follow up if you have a preferred direction.