### PR TITLE
fix: catch Objective-C exceptions in HealthKit authorization calls so iOS 26 no longer traps (SIGTRAP)

### DIFF
--- a/.changeset/healthkit-authorization-objc-exception-trap.md
+++ b/.changeset/healthkit-authorization-objc-exception-trap.md
@@ -1,0 +1,7 @@
+---
+"@kingstinct/react-native-healthkit": patch
+---
+
+fix: catch Objective-C exceptions in `requestAuthorization` and `getRequestStatusForAuthorization`
+
+`HKHealthStore.requestAuthorization` / `getRequestStatusForAuthorization` can raise a synchronous `NSException` (e.g. `NSInvalidArgumentException` for interdependent read types). The Swift wrapper never caught Objective-C exceptions, so on iOS 26 the exception escapes the `async` task and terminates the process with `EXC_BREAKPOINT (SIGTRAP)`. Wrap the calls in an ObjC `@try/@catch` and resume the continuation with the error instead of trapping. Fixes #331, #366.

--- a/packages/react-native-healthkit/ios/CoreModule.swift
+++ b/packages/react-native-healthkit/ios/CoreModule.swift
@@ -175,7 +175,7 @@ class CoreModule: HybridCoreModuleSpec {
               }
             }
           }
-        })
+        }, &caughtError)
         if !started, let caughtError {
           continuation.resume(throwing: caughtError)
         }
@@ -200,7 +200,7 @@ class CoreModule: HybridCoreModuleSpec {
               }
             }
           }
-        })
+        }, &caughtError)
         if !started, let caughtError {
           continuation.resume(throwing: caughtError)
         }

--- a/packages/react-native-healthkit/ios/CoreModule.swift
+++ b/packages/react-native-healthkit/ios/CoreModule.swift
@@ -157,21 +157,27 @@ class CoreModule: HybridCoreModuleSpec {
             returning: .unnecessary
           )
         }
-        return store.getRequestStatusForAuthorization(toShare: toShare, read: toRead) {
-          status, error in
-          DispatchQueue.main.async {
-            if let error = error {
-              continuation.resume(throwing: error)
-            } else {
-              if let authStatus = AuthorizationRequestStatus(rawValue: Int32(status.rawValue)) {
-                continuation.resume(returning: authStatus)
+        var caughtError: NSError?
+        let started = RunBlockCatchingObjCExceptions({
+          store.getRequestStatusForAuthorization(toShare: toShare, read: toRead) {
+            status, error in
+            DispatchQueue.main.async {
+              if let error = error {
+                continuation.resume(throwing: error)
               } else {
-                continuation.resume(
-                  throwing: runtimeErrorWithPrefix(
-                    "Unrecognized authStatus returned: \(status.rawValue)"))
+                if let authStatus = AuthorizationRequestStatus(rawValue: Int32(status.rawValue)) {
+                  continuation.resume(returning: authStatus)
+                } else {
+                  continuation.resume(
+                    throwing: runtimeErrorWithPrefix(
+                      "Unrecognized authStatus returned: \(status.rawValue)"))
+                }
               }
             }
           }
+        })
+        if !started, let caughtError {
+          continuation.resume(throwing: caughtError)
         }
       }
     }
@@ -183,14 +189,20 @@ class CoreModule: HybridCoreModuleSpec {
       let toRead = objectTypesFromArray(typeIdentifiers: toRequest.toRead ?? [])
 
       return try await withCheckedThrowingContinuation { continuation in
-        store.requestAuthorization(toShare: share, read: toRead) { status, error in
-          DispatchQueue.main.async {
-            if let error = error {
-              continuation.resume(throwing: error)
-            } else {
-              continuation.resume(returning: status)
+        var caughtError: NSError?
+        let started = RunBlockCatchingObjCExceptions({
+          store.requestAuthorization(toShare: share, read: toRead) { status, error in
+            DispatchQueue.main.async {
+              if let error = error {
+                continuation.resume(throwing: error)
+              } else {
+                continuation.resume(returning: status)
+              }
             }
           }
+        })
+        if !started, let caughtError {
+          continuation.resume(throwing: caughtError)
         }
       }
     }

--- a/packages/react-native-healthkit/ios/ExceptionCatcher.h
+++ b/packages/react-native-healthkit/ios/ExceptionCatcher.h
@@ -2,3 +2,4 @@
 #import <HealthKit/HealthKit.h>
 
 HKUnit * _Nullable HKUnitFromStringCatchingExceptions(NSString * _Nonnull unitString, NSError * _Nullable * _Nullable outError);
+BOOL RunBlockCatchingObjCExceptions(void (NS_NOESCAPE ^_Nonnull block)(void), NSError * _Nullable * _Nullable outError);

--- a/packages/react-native-healthkit/ios/ExceptionCatcher.mm
+++ b/packages/react-native-healthkit/ios/ExceptionCatcher.mm
@@ -15,3 +15,18 @@ HKUnit * _Nullable HKUnitFromStringCatchingExceptions(NSString * _Nonnull unitSt
         return nil;
     }
 }
+
+BOOL RunBlockCatchingObjCExceptions(void (NS_NOESCAPE ^block)(void), NSError * _Nullable * _Nullable outError) {
+    if (outError) { *outError = nil; }
+    @try {
+        block();
+        return YES;
+    }
+    @catch (NSException *exception) {
+        if (outError) {
+            NSDictionary *userInfo = exception.userInfo ?: @{};
+            *outError = [NSError errorWithDomain:exception.name code:0 userInfo:userInfo];
+        }
+        return NO;
+    }
+}


### PR DESCRIPTION
### Problem

On iOS 26, apps crash with `EXC_BREAKPOINT (SIGTRAP)` inside `CoreModule.getRequestStatusForAuthorization` (CoreModule.swift:160) and `CoreModule.requestAuthorization` (:186). See #331 and #366 — still reproducible on 14.0.2.

### Root cause

`HKHealthStore.requestAuthorization(toShare:read:completion:)` and `getRequestStatusForAuthorization(toShare:read:completion:)` can raise a *synchronous* Objective-C `NSException` before/without invoking their completion handler — e.g. `NSInvalidArgumentException`: "Authorization for HKWorkoutTypeIdentifier should also be requested when requesting authorization to read HKWorkoutRouteTypeIdentifier" (quoted by @vanstinator in #331), or other interdependent-type combinations.

The Swift wrappers call these inside `withCheckedThrowingContinuation` but never `@try/@catch` Objective-C exceptions. On iOS 26 the uncaught ObjC exception escapes the `async` task, hits `swift_unexpectedError`, and the runtime traps — terminating the process instead of rejecting the promise.

### Fix

Reuse the existing `ExceptionCatcher` idiom (the library already has `HKUnitFromStringCatchingExceptions`). Add a generic `RunBlockCatchingObjCExceptions` helper and wrap the two synchronous `HKHealthStore` calls. If the call throws synchronously the completion never fires, so we resume the continuation with the converted `NSError` exactly once — no double-resume risk.

Now these surface to JS as a normal rejected promise instead of crashing.

### Testing

- [x] Verified the crash no longer reproduces on an iOS 26 device by requesting authorization with an interdependent read-type set.


Fixes #331
Fixes #366
