### PR TITLE
ci: collect contract-run diagnostics and relax launch timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,3 +243,13 @@ jobs:
 
       - name: Run HealthKit contracts
         run: bun run test:contracts
+        env:
+          CONTRACT_DIAGNOSTICS_DIR: ${{ runner.temp }}/healthkit-contract-diagnostics
+
+      - name: Upload contract diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: healthkit-contract-diagnostics
+          path: ${{ runner.temp }}/healthkit-contract-diagnostics
+          if-no-files-found: ignore

--- a/apps/example/scripts/run-healthkit-contracts.sh
+++ b/apps/example/scripts/run-healthkit-contracts.sh
@@ -8,6 +8,7 @@ SIMULATOR_ID="${SIMULATOR_ID:-${1:-}}"
 APP_ID="com.kingstinct.reactnativehealthkitexample"
 INITIAL_URL="exp+react-native-healthkit-example://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A8081"
 METRO_LOG="${TMPDIR:-/tmp}/healthkit-contract-metro.log"
+DIAG_DIR="${CONTRACT_DIAGNOSTICS_DIR:-}"
 APP_DATA=""
 REPORT_PATH=""
 COMMAND_PATH=""
@@ -41,12 +42,28 @@ dump_debug_artifacts() {
 
   echo "$reason" >&2
 
+  if [ -z "$DIAG_DIR" ]; then
+    DIAG_DIR="$(mktemp -d -t healthkit-contract-diagnostics)"
+  fi
+  mkdir -p "$DIAG_DIR"
+  echo "$reason" >"$DIAG_DIR/failure-reason.txt"
+
   if [ -n "$SIMULATOR_ID" ]; then
-    local screenshot_path
-    screenshot_path="$(mktemp -t healthkit-contracts-XXXXXX).png"
-    if xcrun simctl io "$SIMULATOR_ID" screenshot "$screenshot_path" >/dev/null 2>&1; then
-      echo "Simulator screenshot: $screenshot_path" >&2
+    if xcrun simctl io "$SIMULATOR_ID" screenshot "$DIAG_DIR/simulator.png" >/dev/null 2>&1; then
+      echo "Simulator screenshot: $DIAG_DIR/simulator.png" >&2
     fi
+
+    xcrun simctl spawn "$SIMULATOR_ID" log show \
+      --last 10m \
+      --style compact \
+      --predicate 'process == "RNHealthKit" OR eventMessage CONTAINS "reactnativehealthkitexample"' \
+      >"$DIAG_DIR/device-log.txt" 2>&1 || true
+
+    xcrun simctl listapps "$SIMULATOR_ID" >"$DIAG_DIR/installed-apps.txt" 2>&1 || true
+
+    find "$HOME/Library/Logs/DiagnosticReports" \
+      \( -name 'RNHealthKit*' -o -name '*reactnativehealthkitexample*' \) \
+      -exec cp {} "$DIAG_DIR/" \; 2>/dev/null || true
   fi
 
   if [ -n "$APP_DATA" ]; then
@@ -56,12 +73,16 @@ dump_debug_artifacts() {
   if [ -n "$REPORT_PATH" ] && [ -f "$REPORT_PATH" ]; then
     echo "Partial contract report:" >&2
     cat "$REPORT_PATH" >&2
+    cp "$REPORT_PATH" "$DIAG_DIR/" 2>/dev/null || true
   fi
 
   if [ -f "$METRO_LOG" ]; then
     echo "Metro log tail:" >&2
     tail -n 200 "$METRO_LOG" >&2
+    cp "$METRO_LOG" "$DIAG_DIR/metro.log" 2>/dev/null || true
   fi
+
+  echo "Diagnostics collected in: $DIAG_DIR" >&2
 }
 
 cleanup() {
@@ -154,7 +175,7 @@ run_with_timeout 20 applesimutils \
   --bundle "$APP_ID" \
   --setPermissions 'health=YES,motion=YES'
 
-run_with_timeout 30 xcrun simctl launch "$SIMULATOR_ID" "$APP_ID" --initialUrl "$INITIAL_URL" >/dev/null
+run_with_timeout 90 xcrun simctl launch "$SIMULATOR_ID" "$APP_ID" --initialUrl "$INITIAL_URL" >/dev/null
 
 ATTEMPT=0
 until [ -f "$REPORT_PATH" ]; do


### PR DESCRIPTION
## Why

The HealthKit contract run is flaky on CI runners — the same commit passed on a feature branch and failed on master/changeset-release 12 minutes later ([example failure](https://github.com/kingstinct/react-native-healthkit/actions/runs/30265139351/job/89982337120)). Two failure flavors observed:

1. `xcrun simctl launch` hits the 30s timeout on a cold first launch (slow/loaded runner)
2. The app launches, but never requests the JS bundle from Metro, so the contract report is never produced

In both cases the debug screenshot was captured to a temp path and then thrown away with the runner, so there's nothing to diagnose with.

## What

- **Bump the `simctl launch` timeout from 30s to 90s** — cold first launch on a loaded GitHub macOS runner can legitimately exceed 30s
- **Collect diagnostics into a stable directory** (`CONTRACT_DIAGNOSTICS_DIR`) on failure: failure reason, simulator screenshot, filtered device log, installed apps, crash reports, partial contract report, and the full Metro log
- **Upload that directory as a workflow artifact** when the contracts step fails, so the next flaky failure tells us whether the dev client is stuck on its launcher screen, showing an error, or crashing

CI-only change: no changeset, no codegen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)