### PR TITLE
fix: insert setupBackgroundObservers into multi-line didFinishLaunchingWithOptions

### DIFF
--- a/.changeset/appdelegate-multiline-signature.md
+++ b/.changeset/appdelegate-multiline-signature.md
@@ -1,0 +1,9 @@
+---
+"@kingstinct/react-native-healthkit": patch
+---
+
+fix: insert `setupBackgroundObservers()` into multi-line `didFinishLaunchingWithOptions` signatures
+
+The config plugin matched the AppDelegate entry point with `/(func application\(.+didFinishLaunchingWithOptions.+\{)\n/`. `.` does not match newlines, so on Expo SDK 54+ — whose AppDelegate template spreads that signature across four lines — the match failed and `String.replace` returned the contents unchanged. The `import HealthKit` insert immediately above it still succeeded and the entitlement and Info.plist plugins still applied, so the build succeeded and the AppDelegate looked modified, while `BackgroundDeliveryManager.shared.setupBackgroundObservers()` was never added. Background delivery then only worked for observers registered by `subscribeToChanges` at runtime, and silently stopped surviving app termination.
+
+Match with `[^{]*` instead, which spans newlines and also refuses to cross a `{`, so it cannot run out of an earlier `application(...)` overload into this one. Also warn when the insert finds no match, rather than failing silently.

--- a/packages/react-native-healthkit/app.plugin.ts
+++ b/packages/react-native-healthkit/app.plugin.ts
@@ -90,12 +90,28 @@ const withAppDelegatePlugin: ConfigPlugin<{
     if (
       !configDelegate.modResults.contents.includes('BackgroundDeliveryManager')
     ) {
-      // Match the opening of didFinishLaunchingWithOptions and insert after the opening brace
-      configDelegate.modResults.contents =
-        configDelegate.modResults.contents.replace(
-          /(func application\(.+didFinishLaunchingWithOptions.+\{)\n/,
-          `$1\n${setupCall}`,
+      // Match the opening of didFinishLaunchingWithOptions and insert after the
+      // opening brace. `[^{]*` rather than `.+` for two reasons: `.` does not
+      // match newlines, and Expo SDK 54+ templates spread this signature over
+      // several lines; and refusing to cross a `{` keeps the match from
+      // spanning out of an earlier `application(...)` overload into this one.
+      const withSetup = configDelegate.modResults.contents.replace(
+        /(func application\([^{]*didFinishLaunchingWithOptions[^{]*\{)\n/,
+        `$1\n${setupCall}`,
+      )
+
+      if (withSetup === configDelegate.modResults.contents) {
+        // Don't fail the build, but don't fail silently either — background
+        // delivery just won't survive app termination, which is otherwise
+        // very hard to trace back to here.
+        console.warn(
+          '[react-native-healthkit] Could not find didFinishLaunchingWithOptions in AppDelegate; ' +
+            'BackgroundDeliveryManager.shared.setupBackgroundObservers() was not inserted. ' +
+            'HealthKit background delivery will not work until it is added manually.',
         )
+      }
+
+      configDelegate.modResults.contents = withSetup
     }
 
     return configDelegate


### PR DESCRIPTION
### The problem

`withAppDelegatePlugin` inserts `BackgroundDeliveryManager.shared.setupBackgroundObservers()` by matching:

```js
/(func application\(.+didFinishLaunchingWithOptions.+\{)\n/
```

`.` doesn't match newlines, so this only works when the whole signature is on one line. Expo SDK 54+ generates a multi-line AppDelegate:

```swift
public override func application(
  _ application: UIApplication,
  didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
) -> Bool {
```

The match fails, `String.replace` returns the contents unchanged, and the setup call is never inserted.

It fails **silently**, which is what makes it expensive. `String.replace` doesn't throw on no-match, the `import HealthKit` insert immediately above it still succeeds, and the entitlement and Info.plist plugins still apply — so `prebuild` succeeds, the AppDelegate is visibly modified, and the entitlements are correct. Everything looks configured.

The runtime symptom is subtle too: `subscribeToChanges` still registers its own observer, so background delivery appears to work while the app is alive. It just never survives termination, since no observer is registered at launch. That's a long way from this regex.

### The fix

Match with `[^{]*` instead of `.+`. It spans newlines, and refusing to cross a `{` also keeps the match from running out of an earlier `application(...)` overload into this one — the SDK 57 template has three `func application(` methods.

Also `console.warn` when the insert finds no match, so the next template change surfaces at prebuild instead of as missing background updates weeks later.

### Verification

Against two fixtures, where the multi-line one deliberately places an `application(_:open:options:)` overload *before* `didFinishLaunchingWithOptions` to confirm the match can't span into it:

| AppDelegate template | before | after |
| --- | --- | --- |
| Expo SDK 54+ (multi-line) | not inserted | inserted, correct position |
| legacy (single-line) | inserted, correct position | inserted, correct position |

So this fixes SDK 54+ without regressing the older single-line template.

### Context

Follow-up to #365. @nopitown reported there that background updates stop arriving after a few deliveries on Expo — on a managed project this is at least one contributing cause, since without the launch-time registration only the observers created at runtime by `subscribeToChanges` exist, and those die with the process.

Biome passes on the changed file. Changeset included as a patch bump.
